### PR TITLE
fix(tests): tornar determinístico test_filter_weekend_events; release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Todas as mudanças notáveis neste projeto serão documentadas neste arquivo.
 O formato é baseado em [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 e este projeto adere ao [Versionamento Semântico](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2025-08-08
+### Corrigido
+- Testes: Tornado determinístico `tests/test_tomada_tempo.py::test_filter_weekend_events` ao ancorar o intervalo do fim de semana na data do evento (01/08/2025), eliminando flakiness dependente de `datetime.now()`.
+- Validação: Suíte completa passando localmente (37 testes) após a correção na branch `fix/logger-initialization`.
+
 ## [Não Lançado]
 ### Adicionado
 - **Documentação de Configuração**

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,17 @@
 
 Este arquivo contém um registro acumulativo de todas as versões lançadas do projeto, com notas detalhadas sobre as mudanças em cada versão.
 
+## Versão 1.0.1 (2025-08-08)
+**Correções de Testes**
+
+### 🐛 Correções
+- Tornado determinístico o teste `tests/test_tomada_tempo.py::test_filter_weekend_events` ao ancorar o intervalo de fim de semana na data do evento (01/08/2025), eliminando flakiness dependente de `datetime.now()`.
+- Suíte de testes completa passando localmente após a correção (37 testes).
+
+### 📈 Impacto
+- Redução de falhas intermitentes no CI.
+- Maior estabilidade na validação de regressão e cobertura.
+
 ## Versão 0.5.0 (2025-08-04)
 **Melhorias no Sistema de Logging e Configuração**
 

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -1,0 +1,17 @@
+# TEST_PLAN
+
+## 2.1.1 Extração e Filtragem (TomadaTempo)
+
+- Correção 2025-08-08: Tornar determinístico `tests/test_tomada_tempo.py::test_filter_weekend_events`.
+  - Antes: intervalo do fim de semana calculado com base em `datetime.now()` via `_get_next_weekend()`.
+  - Depois: intervalo ancorado na própria data do evento de teste (`01/08/2025`, America/Sao_Paulo).
+  - Impacto: elimina flakiness em execuções locais e no CI.
+  - Validação: suíte completa passou localmente (37/37) após a correção.
+
+### Notas
+- Método de produção utilizado: `sources/base_source.py::filter_weekend_events()` (sem alterações funcionais nesta correção).
+- O teste agora usa `BaseSource.parse_date_time()` para garantir timezone-aware e precisão do range do FDS.
+
+### Próximos passos
+- Aumentar cobertura dos módulos críticos (`sources/tomada_tempo.py`, `event_processor.py`).
+- Adicionar casos para AM/PM, datas por extenso e eventos overnight (vide prioridades em TESTING_STANDARDS e plano de qualidade).

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -4,7 +4,7 @@ Motorsport Calendar - Core Modules
 This package contains the core modules for the Motorsport Calendar application.
 """
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 __author__ = "Daniel Mirrha"
 __email__ = "dmirrha@gmail.com"
 

--- a/tests/test_tomada_tempo.py
+++ b/tests/test_tomada_tempo.py
@@ -86,12 +86,8 @@ class TestTomadaTempoSource(unittest.TestCase):
         import pytz
         from datetime import timedelta
         
-        tz = pytz.timezone('America/Sao_Paulo')
-        target_date = self.source._get_next_weekend()
-        
-        # Ensure target_date has timezone
-        if target_date.tzinfo is None:
-            target_date = tz.localize(target_date)
+        # Ancorar o fim de semana na data dos eventos para tornar o teste determinístico
+        target_date = self.source.parse_date_time('01/08/2025', timezone_str='America/Sao_Paulo')
         
         weekend_start = target_date.replace(hour=0, minute=0, second=0, microsecond=0)
         weekend_end = weekend_start + timedelta(days=2, hours=23, minutes=59, seconds=59)


### PR DESCRIPTION
## Contexto

- Corrige flakiness do teste `tests/test_tomada_tempo.py::test_filter_weekend_events` ancorando o intervalo do fim de semana na data fixa do evento (01/08/2025, America/Sao_Paulo).
- Remove dependência de `datetime.now()` no cálculo do range do fim de semana no teste, tornando-o determinístico.

## Mudanças
- tests: atualiza `tests/test_tomada_tempo.py` para cálculo determinístico do FDS.
- release: bump de versão para `1.0.1` em `src/__init__.py`.
- docs: atualiza `CHANGELOG.md` e `RELEASES.md`.
- docs: adiciona `docs/TEST_PLAN.md` com a anotação da correção de flakiness.

## Validação
- Suíte completa passando localmente: **37/37**.

## Impacto
- Reduz falhas intermitentes no CI e aumenta a confiabilidade da suíte.

## Checklist
- [x] Versão atualizada (SemVer)
- [x] Documentação atualizada (CHANGELOG, RELEASES, TEST_PLAN)
- [x] Testes locais aprovados

Sem breaking changes.