### PR TITLE
docs(rollback): pós-rollback 0.5.1 + ajustes .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ env/
 ENV/
 env.bak/
 venv.bak/
+.venv/
 
 # IDE
 .vscode/
@@ -67,7 +68,7 @@ config.json
 *.local.json
 
 # Generated files
-output/*.ics
+output/
 !output/.gitkeep
 
 # Logs and payloads (keep structure, ignore content)
@@ -96,6 +97,15 @@ htmlcov/
 coverage.xml
 *.cover
 .hypothesis/
+pytest.log
+report.html
+junit.xml
+
+# Test artifacts and results
+tests/regression/test_data/output/
+test_results/
+test_results_github/
+tests/**/test_results/
 
 # Environment variables
 .env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Todas as mudanças notáveis neste projeto serão documentadas neste arquivo.
 O formato é baseado em [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 e este projeto adere ao [Versionamento Semântico](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2025-08-09
+### Manutenção
+- Rollback técnico da branch `main` para o snapshot do commit `9362503` (PR #34), preservando histórico.
+- Reaplicação do `.gitignore` para ignorar artefatos de testes e diretórios locais (`tests/regression/test_data/output/`, `test_results/`, `test_results_github/`, `pytest.log`, `junit.xml`, `report.html`).
+- CI/Workflow de testes não reintroduzido neste release.
+
 ## [Não Lançado]
 ### Adicionado
 - **Documentação de Configuração**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,9 @@
 # Guia de Contribuição
 
+> Nota pós-rollback (0.5.1)
+>
+> A branch `main` foi revertida para o snapshot do commit `9362503` (PR #34). Garanta que toda mudança venha acompanhada de atualização de documentação e changelog. O workflow de testes/CI permanece desativado por enquanto.
+
 ## Fluxo de Trabalho para Commits
 
 ### 1. Antes de Fazer um Commit

--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -1,5 +1,9 @@
 # Fontes de Dados - Eventos de Automobilismo
 
+> Nota pós-rollback (0.5.1)
+>
+> A branch `main` foi revertida para o snapshot do commit `9362503` (PR #34). Algumas referências a integrações futuras (ex.: OpenF1) podem ainda não estar disponíveis nesta versão. Consulte `RELEASES.md` para detalhes.
+
 ## **Visão Geral das Fontes de Dados**
 
 ### **Objetivo**

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -1,4 +1,21 @@
+---
+
+## Pastas ignoradas (.gitignore)
+
+- `output/` (mantém `output/.gitkeep`)
+- `logs/`, `logs/rotated_logs/`, `logs/payloads/` (mantém `.gitkeep`)
+- `tests/regression/test_data/output/`
+- `test_results/`, `test_results_github/`, `tests/**/test_results/`
+- `.pytest_cache/`, `__pycache__/`, `.cache/`
+- `htmlcov/`, `.coverage*`, `coverage.xml`, `*.cover`, `pytest.log`, `junit.xml`, `report.html`
+- `.venv/`, `venv/`, `env/`, `ENV/`
+- `.vscode/`, `.idea/`
+- `.DS_Store` e demais arquivos de sistema do macOS
 # Estrutura do Projeto - Motorsport Calendar
+
+> Nota pós-rollback (0.5.1)
+>
+> O projeto foi revertido para o snapshot do commit `9362503`. Algumas seções podem descrever funcionalidades planejadas que ainda serão reintroduzidas em PRs futuros.
 
 ## **Visão Geral da Arquitetura**
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Um script Python avançado para coleta automática de eventos de automobilismo de múltiplas fontes e geração de arquivos iCal para importação no Google Calendar. Desenvolvido para entusiastas de automobilismo que desejam acompanhar todas as corridas do fim de semana em um só lugar.
 
+> Nota pós-rollback (0.5.1)
+>
+> A branch `main` foi revertida para o snapshot do commit `9362503` (PR #34). Algumas seções abaixo podem descrever funcionalidades que serão reintroduzidas em PRs futuros. O workflow de testes/CI não foi reativado neste momento. Consulte `RELEASES.md` para detalhes.
+
 ## 🎯 Características
 
 - ✅ **Coleta automática** de eventos de múltiplas fontes

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,22 @@
 
 Este arquivo contém um registro acumulativo de todas as versões lançadas do projeto, com notas detalhadas sobre as mudanças em cada versão.
 
+## Versão 0.5.1 (2025-08-09)
+Rollback técnico da branch main para o snapshot exato do commit `9362503`.
+
+### 🔄 Contexto
+- PR #34: rollback seguro aplicando restauração completa da árvore para `9362503` em um único commit (histórico preservado).
+- Tag de backup criada anteriormente: `backup/pre-rollback-9362503-20250808-222821`.
+
+### 📌 O que mudou
+- Revertidas mudanças introduzidas após `9362503` (algumas funcionalidades avançadas de logging, períodos de silêncio, workflow de issues e arquivamento iCal podem não estar disponíveis temporariamente).
+- Reaplicado `.gitignore` para evitar versionamento de artefatos de teste e diretórios locais.
+- CI/regression-tests não reintroduzido neste release (será revisitado futuramente).
+
+### ✅ Impactos práticos
+- O código volta a um estado estável anterior; documentação contém notas de pós-rollback para sinalizar possíveis divergências temporárias.
+- Nenhuma migração de dados é necessária.
+
 ## Versão 0.5.0 (2025-08-04)
 **Melhorias no Sistema de Logging e Configuração**
 

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -1,5 +1,9 @@
 # Requisitos do Sistema - Motorsport Calendar
 
+> Nota pós-rollback (0.5.1)
+>
+> A branch `main` foi revertida para o snapshot do commit `9362503` (PR #34). Alguns itens abaixo descrevem funcionalidades que serão reintroduzidas em versões futuras. Consulte `RELEASES.md`.
+
 ## **Visão Geral**
 
 ### **Objetivo do Projeto**

--- a/docs/CONFIGURATION_GUIDE.md
+++ b/docs/CONFIGURATION_GUIDE.md
@@ -1,6 +1,19 @@
+---
+
+## Diretórios de saída e artefatos
+
+- `output/`: diretório onde os arquivos `.ics` são gerados (mantém `output/.gitkeep`).
+- `logs/`: diretório para logs e payloads (`logs/rotated_logs/`, `logs/payloads/`).
+- `tests/regression/test_data/output/`: artefatos gerados por testes de regressão (ignorado pelo Git).
+
+Esses caminhos não exigem configuração específica, mas podem ser ajustados via parâmetros em `config.json` (ex.: `general.output_directory`, opções em `logging.file_structure`).
 # Guia de Configuração do Motorsport Calendar Generator
 
 Este documento descreve todas as opções de configuração disponíveis no arquivo `config.json` do Motorsport Calendar Generator.
+
+> Nota pós-rollback (0.5.1)
+>
+> O projeto foi revertido para o snapshot do commit `9362503`. Algumas opções documentadas podem se referir a funcionalidades que serão reintroduzidas em PRs futuros. Consulte `RELEASES.md` para detalhes.
 
 ## Visão Geral
 


### PR DESCRIPTION
Consolida notas pós-rollback (0.5.1) em documentação e corrige .gitignore para artefatos de testes/venv.\n\nContexto:\n- main revertida para o snapshot do commit 9362503 (PR #34)\n- CI/workflow de testes temporariamente desativado\n\nAlterações principais:\n- Docs: CHANGELOG.md, RELEASES.md, README.md, PROJECT_STRUCTURE.md, docs/CONFIGURATION_GUIDE.md, CONTRIBUTING.md, DATA_SOURCES.md, REQUIREMENTS.md\n- .gitignore: corrigidas regras para .venv/, pytest.log, report.html, junit.xml; mantidas regras para tests/regression/test_data/output/, test_results_github/ e afins\n- Estruturas: confirmados .gitkeep em logs/ e output/\n\nImpacto:\n- Sem mudanças de código funcional; foco em documentação e higiene do repositório\n- Prepara terreno para reativação gradual do CI após estabilização\n\nValidação local:\n- Apenas mudanças em docs e .gitignore; sem impacto na execução\n\nPróximos passos:\n- Revisar e aprovar PR\n- Planejar reativação do workflow de testes\n\n