### PR TITLE
ci(release-drafter): reativar Release Drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,21 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * *'
+
+jobs:
+  update_release_draft:
+    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release Drafter
+        uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reativa automação de notas de release via Release Drafter.\n\nArquivos adicionados:\n-  (workflow)\n-  (config existente já confirmada)\n\nMotivação:\n- Após rollback, workflows de CI foram desativados/ausentes. Este PR restaura o draft automático de releases, alinhado ao nosso processo SemVer e Release Drafter.\n\nPós-merge:\n- O workflow atualizará/gerará o draft automaticamente em pushes para .\n- Publicar a release para a tag já criada: .\n\nImpacto:\n- Sem alterações de código funcional. Apenas CI/automação de releases.