### PR TITLE
chore(tests/docs): gate 45% + cobertura 57.86% (170 passed); sincroniza documentação

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/spec/v2.0.
     - Cobertura do arquivo: **76%**; suíte: **156 passed**; cobertura global: **51.92%**
     - Novos testes: `tests/unit/ical/test_ical_generator_extended.py`
     - Nota: corrigido efeito colateral de monkeypatch global em `pytz.timezone` nos testes de processamento para não interferir nos testes de iCal
-  - Fase 1: configuração mínima do Pytest com cobertura e documentação
+   - Fase 1: configuração mínima do Pytest com cobertura e documentação
     - `pytest.ini`: `testpaths=tests`; cobertura em `src/` e `sources/` com `--cov=src --cov=sources`
     - Relatórios: `--cov-report=term-missing:skip-covered`, `--cov-report=xml:coverage.xml`, `--cov-report=html`, `--junitxml=test_results/junit.xml`
     - Gate de cobertura inicial: `--cov-fail-under=40`
@@ -113,6 +113,14 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/spec/v2.0.
     - Documentação de cenários atualizada:
       - `docs/tests/scenarios/SCENARIOS_INDEX.md`
       - `docs/tests/scenarios/phase1_scenarios.md`
+   - Issue #63: Gate de cobertura global elevado para 45%
+     - `pytest.ini`: `--cov-fail-under=45`
+     - Suíte: **170 passed**; cobertura global: **57.86%**
+     - Novos testes:
+       - `tests/unit/category/test_category_detector_basic.py`
+       - `tests/unit/utils/test_payload_manager_extended.py`
+       - `tests/unit/config/test_config_manager_basic.py`
+     - Documentação sincronizada: `tests/README.md`, `docs/TEST_AUTOMATION_PLAN.md`, `README.md`, `CHANGELOG.md`, `RELEASES.md`, `docs/issues/open/issue-63.{md,json}`
  - Fase 1 — Alvos prioritários (issue #49, PR #56)
    - Testes unitários para parsers de data/hora em `sources/tomada_tempo.py` e validações em `sources/base_source.py`
    - Testes unitários para processadores/validadores em `src/event_processor.py` (`_is_event_valid`, `_filter_weekend_events`)

--- a/README.md
+++ b/README.md
@@ -242,9 +242,9 @@ cp config/config.example.json config/config.json
 
 ## 🧪 Testes
 
-A suíte utiliza Pytest com cobertura via pytest-cov. Durante a estabilização dos mocks essenciais (issue #48), o gate de cobertura global está temporariamente em 25%.
+A suíte utiliza Pytest com cobertura via pytest-cov. O gate de cobertura global está configurado em **45%**.
 
-- Gate temporário: `--cov-fail-under=25` (definido em `pytest.ini`)
+- Gate atual: `--cov-fail-under=45` (definido em `pytest.ini`)
 - Mocks essenciais:
   - Timezone fixo `America/Sao_Paulo` e aleatoriedade determinística (`random.seed(0)`)
   - Shims de rede: `sources.tomada_tempo.requests.get` e `sources.base_source.requests.Session`
@@ -263,6 +263,11 @@ Cobertura e métricas recentes (Fase 1.1 — issue #62):
 - Suíte: **156 passed**; cobertura global: **51.92%**
 - Novos testes: `tests/unit/ical/test_ical_generator_extended.py`
 - Nota: corrigido efeito colateral de monkeypatch global em `pytz.timezone` nos testes de processamento para não interferir nos testes de iCal
+
+Cobertura e métricas recentes (Fase 1.1 — issue #63):
+- Suíte: **170 passed**; cobertura global: **57.86%**
+- Gate global: `--cov-fail-under=45`
+- Novos testes: `tests/unit/category/test_category_detector_basic.py`, `tests/unit/utils/test_payload_manager_extended.py`, `tests/unit/config/test_config_manager_basic.py`
 
 ## 🚀 Uso
 
@@ -578,9 +583,9 @@ open htmlcov/index.html  # macOS
 ```
 
 Notas:
-- Gate de cobertura temporário: 25% (`--cov-fail-under=25`) — estabilização dos mocks essenciais (issue #48, PR #55).
-- Timezone padrão dos testes: `America/Sao_Paulo` (fixture autouse em `tests/conftest.py`).
-- Mocks essenciais documentados em `tests/README.md`:
+- Gate de cobertura global: 45% (`--cov-fail-under=45`).
+ - Timezone padrão dos testes: `America/Sao_Paulo` (fixture autouse em `tests/conftest.py`).
+ - Mocks essenciais documentados em `tests/README.md`:
   - TZ e aleatoriedade fixas (fixtures autouse em `tests/conftest.py`).
   - Rede com shims/patches (`patch_requests_get`, `patch_requests_session`).
   - Isolamento de filesystem com `tmp_path`.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -56,6 +56,16 @@ Issue #62 (PR #69 — draft)
 - Novos testes: `tests/unit/ical/test_ical_generator_extended.py`
 - Observação: corrigido side-effect de monkeypatch global em `pytz.timezone` nos testes de processamento para não interferir nos testes de iCal
 
+Issue #63
+
+- Gate global de cobertura ajustado em `pytest.ini`: `--cov-fail-under=45`
+- Suíte: **170 passed**; cobertura global: **57.86%**
+- Novos testes adicionados:
+  - `tests/unit/category/test_category_detector_basic.py`
+  - `tests/unit/utils/test_payload_manager_extended.py`
+  - `tests/unit/config/test_config_manager_basic.py`
+- Documentação sincronizada: `tests/README.md`, `docs/TEST_AUTOMATION_PLAN.md`, `README.md`, `CHANGELOG.md`, `RELEASES.md`, `docs/issues/open/issue-63.{md,json}`
+
 Fase 1 — Cenários (issue #50, PR #57 draft)
 
 - Fixtures HTML adicionados para o parser `TomadaTempoSource`:

--- a/docs/TEST_AUTOMATION_PLAN.md
+++ b/docs/TEST_AUTOMATION_PLAN.md
@@ -188,8 +188,9 @@ Objetivo: elevar a cobertura unitária para ≥ 80%, ampliando a matriz de casos
   - [x] Novos testes: `tests/unit/ical/test_ical_generator_extended.py`
   - [x] Nota: corrigido side-effect de monkeypatch global em `pytz.timezone` nos testes de processamento
 - [ ] #63 — Gate global ≥ 45% (`pytest.ini`)
-  - [ ] Automação local
-    - [ ] Script/Makefile com alvos `test:unit`, `test:integration`, `coverage`, `report`
+  - [x] Métricas (2025-08-12): suíte **170 passed**; cobertura global **57.86%**; gate aplicado em `pytest.ini` (`--cov-fail-under=45`)
+  - [x] Automação local
+    - [x] Script/Makefile com alvos `test.unit`, `test.integration`, `coverage`, `report`
 - [ ] #64 — Documentação e Cenários (sincronismo)
 
 # Fase 1.2 — Fixtures “golden” para ICS (Snapshots)

--- a/docs/issues/open/issue-63.json
+++ b/docs/issues/open/issue-63.json
@@ -9,9 +9,9 @@
   "created_at": "2025-08-10T21:03:08Z",
   "updated_at": "2025-08-10T21:07:18Z",
   "tasks": [
-    {"item": "Atualizar pytest.ini (fail-under=45)", "done": false},
-    {"item": "Garantir suíte passando localmente", "done": false},
-    {"item": "Atualizar documentação e releases", "done": false}
+    {"item": "Atualizar pytest.ini (fail-under=45)", "done": true},
+    {"item": "Garantir suíte passando localmente", "done": true},
+    {"item": "Atualizar documentação e releases", "done": true}
   ],
   "acceptance": [
     "Suíte passando com gate 45%",

--- a/docs/issues/open/issue-63.md
+++ b/docs/issues/open/issue-63.md
@@ -14,9 +14,52 @@ Elevar o gate de cobertura global para ≥45% no `pytest.ini`.
 
 ## PARE — Autorização
 - PR inicia em draft até validação deste plano.
+ - Aprovado pelo usuário em 2025-08-11T21:51:43-03:00.
 
 ## Progresso
-- [ ] Branch criada
-- [ ] PR (draft) aberta
-- [ ] Suíte passando com gate
-- [ ] Documentação sincronizada
+ - [x] Branch criada (chore/issue-63-coverage-gate-45)
+ - [ ] PR (draft) aberta
+ - [x] Suíte passando com gate (45%)
+ - [x] Documentação sincronizada
+
+## Plano de Resolução
+
+1) Preparação e validação
+- Confirmar correção do leak de `monkeypatch` em `tests/unit/processing/test_event_processor_pipeline.py` (já validado anteriormente com 156 passed e ~51.92% cobertura)
+- Documentar evidências de execução local neste arquivo (logs resumidos)
+
+2) Gate de cobertura
+- Atualizar `pytest.ini` para `--cov-fail-under=45` (ou chave equivalente na seção `[tool:pytest]`)
+- Padronizar comandos recomendados:
+  - `pytest --cov=src --cov-report=term-missing --cov-fail-under=45`
+  - `pytest -q` para execução rápida
+
+3) Sincronização documental
+- Atualizar `README.md` (requisitos, como rodar testes, gate 45%)
+- Atualizar `tests/README.md` (comandos com gate, práticas de patch/monkeypatch)
+- Atualizar `docs/TEST_AUTOMATION_PLAN.md` (refletir gate da Fase 1.1)
+- Atualizar `CHANGELOG.md` e `RELEASES.md` conforme SemVer (0.x.y) e política de notas cumulativas
+
+4) Automação/qualidade (se aplicável)
+- Verificar targets no `Makefile` para testes+cobertura (ex.: `make test`, `make coverage`)
+- Adicionar/ajustar badges de cobertura no `README.md` (se presentes)
+
+5) PR e rastreabilidade
+- Abrir PR em draft a partir da branch `chore/issue-63-coverage-gate-45`
+- Vincular a issue #63 e seguir checklist de conformidade
+- Após validação, marcar a seção "PARE — Autorização" como aprovada e prosseguir com merge
+
+## PARE — Autorização aprovada (2025-08-11T21:51:43-03:00)
+Confirma que devo prosseguir com:
+- Atualização do `pytest.ini` para gate 45%
+- Execução da suíte com o gate
+- Sincronização de documentação e atualização dos arquivos listados
+
+## Evidências
+- Gate configurado em `pytest.ini`: `--cov-fail-under=45`
+- Execução local: **170 passed**; cobertura global: **57.86%**
+- Novos testes adicionados:
+  - `tests/unit/category/test_category_detector_basic.py`
+  - `tests/unit/utils/test_payload_manager_extended.py`
+  - `tests/unit/config/test_config_manager_basic.py`
+ - Documentação sincronizada: `tests/README.md`, `docs/TEST_AUTOMATION_PLAN.md`, `README.md`, `CHANGELOG.md`, `RELEASES.md`

--- a/tests/README.md
+++ b/tests/README.md
@@ -37,7 +37,7 @@ Este diretório contém a suíte de testes do projeto. A descoberta de testes é
     --cov-report=term-missing:skip-covered \
     --cov-report=xml:coverage.xml --cov-report=html \
     --junitxml=test_results/junit.xml`
-  - Gate temporário de cobertura: `--cov-fail-under=25` (estabilização dos mocks essenciais, issue #48)
+  - Gate global de cobertura: `--cov-fail-under=45` (issue #63)
   
 ### Métricas recentes
 - Fase 1.1 — issue #60
@@ -60,6 +60,14 @@ Este diretório contém a suíte de testes do projeto. A descoberta de testes é
    - Cobertura de `src/ical_generator.py`: **76%**
    - Novos testes: `tests/unit/ical/test_ical_generator_extended.py`
    - Nota: corrigido efeito colateral de monkeypatch global em `pytz.timezone` nos testes de processamento para não interferir nos testes de iCal
+
+ - Fase 1.1 — issue #63
+   - Suíte: **170 passed**; cobertura global: **57.86%**
+   - Gate global em `pytest.ini`: `--cov-fail-under=45`
+   - Novos testes:
+     - `tests/unit/category/test_category_detector_basic.py`
+     - `tests/unit/utils/test_payload_manager_extended.py`
+     - `tests/unit/config/test_config_manager_basic.py`
 
 ### Destaques — BaseSource (issue #60)
 - HTTP 4xx com retries e logs


### PR DESCRIPTION
Closes #63

# Contexto
- Gate global de cobertura ajustado em `pytest.ini`: `--cov-fail-under=45`.
- Suíte validada localmente: **170 passed**; cobertura global: **57.86%**.
- Novos testes:
  - `tests/unit/category/test_category_detector_basic.py`
  - `tests/unit/utils/test_payload_manager_extended.py`
  - `tests/unit/config/test_config_manager_basic.py`

# Mudanças
- Atualiza documentação para refletir gate 45% e métricas atuais:
  - `README.md`
  - `tests/README.md`
  - `docs/TEST_AUTOMATION_PLAN.md`
  - `CHANGELOG.md`
  - `RELEASES.md`
  - `docs/issues/open/issue-63.md`
  - `docs/issues/open/issue-63.json`

# Evidências de Execução
- Saída do Pytest/coverage:
  - `Required test coverage of 45% reached. Total coverage: 57.86%`
  - Relatórios: `coverage.xml`, `htmlcov/`, `test_results/junit.xml`

# Checklist de Sincronização
- [x] Issue no GitHub atualizada (rastreabilidade)
- [x] PR (draft) com métricas e referência à issue
- [x] Documentos padrão sincronizados: `CHANGELOG.md`, `RELEASES.md`, `README.md`, `tests/README.md`, `docs/TEST_AUTOMATION_PLAN.md`
- [x] Arquivos de rastreabilidade atualizados: `docs/issues/open/issue-63.{md,json}`

# Observações
- Menções históricas ao gate 25% foram mantidas apenas em seções de releases passados (notas cumulativas).
- Makefile disponibiliza automação local: `make test`, `make test.unit`, `make test.integration`, `make coverage`, `make report`.
