### PR TITLE
chore(docs): Governança Fase 2 — épico #78 e sub-issues #79–#86

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/spec/v2.0.
 - CI/Workflow de testes não reintroduzido neste release.
 
 ## [Não Lançado]
+### Governança — Fase 2 (Testes Integrados e Validação de ICS)
+- Épico #78 e sub-issues #79–#86 registrados e vinculados (checklist no épico)
+- Documentação sincronizada: `docs/TEST_AUTOMATION_PLAN.md`, `README.md`, `RELEASES.md`, `CHANGELOG.md`
+- Rastreabilidade criada/atualizada: `docs/issues/open/issue-{78..86}.{md,json}`
+- README — seção "🧪 Testes": adicionada nota de Fase 2 (governança)
 ### Adicionado
 - **Documentação de Configuração**
   - Criado `CONFIGURATION_GUIDE.md` com documentação detalhada de todas as opções de configuração

--- a/README.md
+++ b/README.md
@@ -252,6 +252,13 @@ A suíte utiliza Pytest com cobertura via pytest-cov. O gate de cobertura global
   - Variáveis de ambiente com `monkeypatch.setenv`/`delenv`
 - Como rodar: consulte `tests/README.md` para comandos, estrutura e exemplos.
 
+### Fase 2 — Testes Integrados (Governança)
+
+- Épico: #78 — Testes Integrados e Validação de ICS
+- Sub-issues: #79–#86
+- Documentação sincronizada: `docs/TEST_AUTOMATION_PLAN.md`, `CHANGELOG.md`, `RELEASES.md`
+- Rastreabilidade: `docs/issues/open/issue-{78..86}.{md,json}`
+
 Comandos rápidos (local):
 
 ```bash

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -24,6 +24,12 @@ Manutenção — Testes/Automação (issue #48, PR #55)
   - Concurrency com `cancel-in-progress`
   - Documentação atualizada: `README.md`, `tests/README.md`, `CHANGELOG.md`
 
+### Governança — Fase 2 (Testes Integrados e Validação de ICS)
+
+- Épico: #78; Sub-issues: #79–#86
+- Documentação sincronizada: `docs/TEST_AUTOMATION_PLAN.md`, `README.md`, `CHANGELOG.md`, `RELEASES.md`
+- Rastreabilidade: `docs/issues/open/issue-{78..86}.{md,json}`
+
 - Fase 1.1 — Checklist reorganizada por issues (#59–#64) com sincronismo automático entre plano (`docs/TEST_AUTOMATION_PLAN.md`) e issues (docs/issues/open/issue-<n>.{md,json}); rastreabilidade 58–64 adicionada.
 
 Issue #61 (PR #68 — draft)

--- a/docs/TEST_AUTOMATION_PLAN.md
+++ b/docs/TEST_AUTOMATION_PLAN.md
@@ -305,8 +305,11 @@ Objetivo: Validar fluxos entre componentes (coleta → processamento → iCal), 
   - [ ] Consistência de timezone (naive → localized conforme config)
 - [ ] Documentação e rastreabilidade (Fase 2)
   - [ ] Criar/atualizar `docs/tests/scenarios/phase2_scenarios.md` (fluxos, casos, status e links)
- - [ ] Adicionar itens derivados como checklist nesta seção do plano
- - [ ] Automação CI (final da Fase 2)
+  - [x] Governança Fase 2: épico #78 e sub-issues #79–#86 criados
+  - [x] Link do épico: https://github.com/dmirrha/motorsport-calendar/issues/78
+  - [x] Sincronismo de documentos: `README.md`, `docs/TEST_AUTOMATION_PLAN.md`, `CHANGELOG.md`, `RELEASES.md`
+  - [ ] Adicionar itens derivados como checklist nesta seção do plano
+  - [ ] Automação CI (final da Fase 2)
    - [ ] GitHub Actions: workflow para unit/integration com `pytest` + `pytest-cov`
    - [ ] Upload de artefatos (HTML/ XML) e envio ao Codecov
    - [ ] Codecov: upload de `coverage.xml`, status check e badge no `README.md`


### PR DESCRIPTION
Sincroniza documentação de Fase 2 (README, TEST_AUTOMATION_PLAN, CHANGELOG e RELEASES). Rastreabilidade em docs/issues/open/issue-{78..86}.{md,json}. Refs: #78