### PR TITLE
chore(docs): arquiva Issue #83 em docs/issues/closed

### DIFF
--- a/docs/issues/closed/issue-83-2025-08-14.json
+++ b/docs/issues/closed/issue-83-2025-08-14.json
@@ -1,13 +1,13 @@
 {
   "id": 3318324966,
   "number": 83,
-  "state": "open",
+  "state": "closed",
   "title": "Fase 2 — Documentação e Rastreabilidade",
   "milestone": null,
   "epic": 78,
   "url": "https://github.com/dmirrha/motorsport-calendar/issues/83",
   "created_at": "2025-08-13T12:44:07Z",
-  "updated_at": "2025-08-14T15:00:36Z",
+  "updated_at": "2025-08-14T15:24:22Z",
   "tasks": [
     {"item": "Atualizar docs/TEST_AUTOMATION_PLAN.md (Fase 2)", "done": true},
     {"item": "Atualizar tests/README.md (-m integration)", "done": true},
@@ -18,5 +18,8 @@
     "Arquivos obrigatórios sincronizados",
     "Referências cruzadas entre issues/PRs e docs",
     "Checklist validado"
-  ]
+  ],
+  "work_branch": "tests/issue-83-docs-traceability",
+  "pr_number": 100,
+  "pr_url": "https://github.com/dmirrha/motorsport-calendar/pull/100"
 }

--- a/docs/issues/closed/issue-83-2025-08-14.md
+++ b/docs/issues/closed/issue-83-2025-08-14.md
@@ -9,8 +9,10 @@ Referências:
 
 ## Branch/PR/Links
 - Branch: `tests/issue-83-docs-traceability`
-- PR: (pendente)
-- Atualizado em (UTC): 2025-08-14T15:00:36Z
+- PR: #100 (https://github.com/dmirrha/motorsport-calendar/pull/100)
+- Merged em (UTC): 2025-08-14T15:20:04Z
+- Merge commit: 7e0e99c
+- Atualizado em (UTC): 2025-08-14T15:24:22Z
 
 ## Descrição
 Atualizar documentação e garantir rastreabilidade entre épico, histórias, PRs e plano de testes.
@@ -22,9 +24,9 @@ Atualizar documentação e garantir rastreabilidade entre épico, histórias, PR
 - [x] CHANGELOG.md e RELEASES.md (entrada Fase 2)
 
 ## Critérios de Aceite
-- [ ] Todos os arquivos obrigatórios sincronizados
-- [ ] Referências cruzadas entre issues/PRs e docs
-- [ ] Checklist validado
+- [x] Todos os arquivos obrigatórios sincronizados
+- [x] Referências cruzadas entre issues/PRs e docs
+- [x] Checklist validado
 
 ## Progresso
 - [x] Atualizações aplicadas


### PR DESCRIPTION
Housekeeping: move os artefatos de rastreabilidade da Issue #83 para `docs/issues/closed/` e atualiza metadados de PR/merge.

- MD: `docs/issues/closed/issue-83-2025-08-14.md` — atualiza seção Branch/PR/Links com PR #100, merged_at e merge_commit; critérios de aceite marcados ✅
- JSON: `docs/issues/closed/issue-83-2025-08-14.json` — adiciona `work_branch`, `pr_number`, `pr_url`, `updated_at`

Notas:
- Sem alterações funcionais (apenas documentação/arquivamento)
- Fluxo padrão: após merge, apagar a branch de housekeeping
