### PR TITLE
ci: robustez no upload do Codecov (paths absolutos + verificação de arquivos)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,12 +79,11 @@ jobs:
         if: always()
         uses: codecov/codecov-action@v4
         with:
-          files: coverage.xml
+          files: ${{ github.workspace }}/coverage.xml
           flags: unit
           fail_ci_if_error: false
           verbose: true
           use_oidc: true
-          disable_search: true
 
       - name: Upload test results to Codecov (Tests Analytics)
         if: always()
@@ -161,16 +160,23 @@ jobs:
           fail_ci_if_error: false
           verbose: true
       
+      - name: Verify coverage file (e2e)
+        if: always()
+        run: |
+          echo "Verificando coverage_e2e.xml"
+          ls -l coverage_e2e.xml || true
+          wc -c coverage_e2e.xml || true
+          head -n 5 coverage_e2e.xml || true
+
       - name: Upload coverage to Codecov (e2e)
         if: always()
         uses: codecov/codecov-action@v4
         with:
-          files: coverage_e2e.xml
+          files: ${{ github.workspace }}/coverage_e2e.xml
           flags: e2e
           fail_ci_if_error: false
           verbose: true
           use_oidc: true
-          disable_search: true
       
       - name: Upload E2E test results to Codecov (Tests Analytics)
         if: always()
@@ -250,16 +256,23 @@ jobs:
           fail_ci_if_error: false
           verbose: true
 
+      - name: Verify coverage file (integration)
+        if: always()
+        run: |
+          echo "Verificando coverage_integration.xml"
+          ls -l coverage_integration.xml || true
+          wc -c coverage_integration.xml || true
+          head -n 5 coverage_integration.xml || true
+
       - name: Upload coverage to Codecov (integration)
         if: always()
         uses: codecov/codecov-action@v4
         with:
-          files: coverage_integration.xml
+          files: ${{ github.workspace }}/coverage_integration.xml
           flags: integration
           fail_ci_if_error: false
           verbose: true
           use_oidc: true
-          disable_search: true
 
       - name: Upload integration test results to Codecov (Tests Analytics)
         if: always()


### PR DESCRIPTION
Contexto
- Corrige falhas intermitentes no upload do Codecov (exit code 1) nos jobs e2e/integration.
- Segue as diretrizes atuais do workflow e dos flags no Codecov (OIDC ativo).

Mudanças
- codecov/codecov-action: usa caminhos absolutos para coverage files (e.g., `${{ github.workspace }}/coverage_integration.xml`).
- codecov/codecov-action: remove `disable_search` para evitar falhas por resolução de path.
- Adiciona passo de verificação pré-upload (ls, wc, head) dos arquivos `coverage_e2e.xml` e `coverage_integration.xml` para diagnóstico rápido.
- Mantém o upload via test-results-action (Tests Analytics) como está.

Motivação
- Endereça falhas intermitentes de upload sem impactar geração de cobertura.
- Facilita troubleshooting com logs adicionais antes do upload.

Validação esperada
- CI no PR deve executar os três jobs e completar uploads no Codecov sem erro.
- Flags: unit, e2e e integration preservadas.

Próximos passos
- Se estabilizado, prosseguir com a tag/release 0.5.19 conforme notas já preparadas.