### PR TITLE
ci(coverage): ajustes de flags e escopos por job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,8 @@ jobs:
         run: |
           mkdir -p test_results
           pytest \
+            -m "not integration" \
+            -k "not test_phase2_e2e_" \
             --cov-config=.coveragerc \
             --cov=src --cov=sources \
             --cov-report=term-missing:skip-covered \
@@ -164,9 +166,10 @@ jobs:
           pytest -q -c /dev/null \
             --cov-config=.coveragerc \
             tests/integration/test_phase2_e2e_*.py \
-            --cov-config=.coveragerc \
-            --cov=src \
-            --cov=sources \
+            --cov=src/data_collector.py \
+            --cov=src/event_processor.py \
+            --cov=src/ical_generator.py \
+            --cov=sources/tomada_tempo.py \
             --cov-report=term-missing:skip-covered \
             --cov-report=xml:coverage_e2e.xml \
             --cov-report=html:htmlcov-e2e \
@@ -281,8 +284,14 @@ jobs:
           mkdir -p test_results_integration
           pytest -q -c /dev/null -m integration \
             --cov-config=.coveragerc \
-            --cov=src \
-            --cov=sources \
+            --cov=src/config_manager.py \
+            --cov=src/silent_period.py \
+            --cov=src/category_detector.py \
+            --cov=src/ical_generator.py \
+            --cov=src/event_processor.py \
+            --cov=src/data_collector.py \
+            --cov=sources/base_source.py \
+            --cov=sources/tomada_tempo.py \
             --cov-report=term-missing:skip-covered \
             --cov-report=xml:coverage_integration.xml \
             --cov-report=html:htmlcov-integration \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ O formato é baseado em [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 e este projeto adere ao [Versionamento Semântico](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### CI/Tests — Cobertura por flags (ajuste unit/integration/e2e)
+- Job `unit`: passa a excluir explicitamente testes `integration` e `test_phase2_e2e_*` para evitar diluição da cobertura por flag (`-m "not integration"` e `-k "not test_phase2_e2e_"`).
+- Job `integration`: mantém `pytest -m integration` com cobertura focada em módulos do fluxo principal (src/ e sources/ relevantes) para refletir melhor a suíte de integração no Codecov (flag `integration`).
+- Job `e2e`: executa todos os `tests/integration/test_phase2_e2e_*.py` (não apenas `-k happy`) com cobertura focada no pipeline end‑to‑end (flag `e2e`).
+- Documentação: `docs/tests/overview.md` atualizado descrevendo a separação de escopos e a política de marcadores.
 
 ## [0.5.21] - 2025-08-18
 ### CI/Codecov — Cobertura e uploads restritos a XML

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3,6 +3,12 @@
 Este arquivo contém um registro acumulativo de todas as versões lançadas do projeto, com notas detalhadas sobre as mudanças em cada versão.
 
 ## Não Lançado
+CI/Tests — Cobertura por flags (ajuste unit/integration/e2e)
+
+- Job `unit`: passa a excluir explicitamente testes `integration` e o conjunto `tests/integration/test_phase2_e2e_*.py` para evitar diluição do denominador das flags (`-m "not integration"` e `-k "not test_phase2_e2e_"`).
+- Job `integration`: mantém `pytest -m integration` com cobertura focada em módulos do fluxo principal (src/ e sources/ relevantes), refletindo melhor a suíte no Codecov (flag `integration`).
+- Job `e2e`: executa todos os `tests/integration/test_phase2_e2e_*.py` (não apenas `-k happy`) com cobertura focada no pipeline end‑to‑end (flag `e2e`).
+- Documentação: `docs/tests/overview.md` e `CHANGELOG.md` atualizados com a separação de escopos e política de marcadores.
 
 ## Versão 0.5.21 (2025-08-18)
 

--- a/docs/tests/overview.md
+++ b/docs/tests/overview.md
@@ -55,6 +55,7 @@ Objetivo: descrever a estratégia mínima de testes para o projeto, com foco em 
 - Job `e2e`: executa todos os `tests/integration/test_phase2_e2e_*.py` com cobertura focada no pipeline E2E (`src/data_collector.py`, `src/event_processor.py`, `src/ical_generator.py`, `sources/tomada_tempo.py`). Antes rodava apenas `-k happy`.
 - Testes de integração relevantes receberam `pytestmark = pytest.mark.integration` para inclusão no job `integration` (ex.: `test_phase2_basic.py`, `test_phase2_optionals.py`, `test_phase2_overnight.py`, `test_phase2_timezones.py`).
 - Observação: testes E2E não devem usar o marcador `integration`; são executados separadamente pelo job `e2e` no CI.
+- Job `unit`: exclui explicitamente `integration` e o conjunto `test_phase2_e2e_*` via `-m "not integration"` e `-k "not test_phase2_e2e_"` para evitar diluição do denominador de cobertura das flags.
 
 ### Política de marcadores (automática)
 - Teste de política: `tests/policy/test_markers_policy.py` valida que:


### PR DESCRIPTION
Ajusta escopos de cobertura para unit/integration/e2e conforme documentação. Atualiza CHANGELOG e RELEASES. Objetivo: evitar diluição de cobertura por flag e melhorar qualidade dos relatórios no Codecov.