### PR TITLE
chore(release): 0.5.22 — TomadaTempo IT1 (docs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/spec/v2.0.
   - Caso ausente, gerar via `python -m coverage xml -i -o <arquivo>` (garante artefato para upload no Codecov com `disable_search: true`).
   - Logs mantidos no workflow para facilitar diagnóstico.
 
+## [0.5.22] - 2025-08-18
+### Integração — TomadaTempo IT1 (Issue #105, PR #119)
+
+- Parser `sources/tomada_tempo.py`: cobertura de variantes essenciais com cenários determinísticos.
+- Casos cobertos: caminho feliz; campos opcionais ausentes tratados com segurança; tolerância a HTML malformado com fallbacks (sem crash).
+- Testes de integração: execução local estável da suíte `pytest -m integration`; cobertura consolidada ~48% no run; 3× sem flakes.
+- Documentação sincronizada: `RELEASES.md` e `docs/tests/overview.md`.
+- Versionamento: bump para `0.5.22` aplicado em `src/__init__.py`.
+
 ## [0.5.21] - 2025-08-18
 ### CI/Codecov — Cobertura e uploads restritos a XML
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -19,7 +19,16 @@
    - Caso ausente, gerar via `python -m coverage xml -i -o <arquivo>` para garantir artefato consistente.
    - Uploads explicitamente apontando para os XMLs esperados com `disable_search: true` para evitar arquivos indevidos.
 
- ## Versão 0.5.21 (2025-08-18)
+## Versão 0.5.22 (2025-08-18)
+
+Integração — TomadaTempo IT1 (Issue #105, PR #119)
+
+- Escopo: robustez do parser `sources/tomada_tempo.py` em cenários determinísticos cobrindo caminho feliz, campos opcionais ausentes e tolerância a HTML malformado (com fallbacks, sem crash).
+- Testes de integração: suíte estável localmente com `pytest -m integration`; métricas observadas ~48% de cobertura no run; múltiplas execuções sem flakes. Em ciclos recentes: 23 passed, 3 skipped, 1 xfailed.
+- Documentação sincronizada: `CHANGELOG.md` e `docs/tests/overview.md` atualizados.
+- Versionamento: bump para `0.5.22` em `src/__init__.py`.
+
+## Versão 0.5.21 (2025-08-18)
 
  CI/Codecov — Cobertura e uploads restritos a XML
 

--- a/docs/tests/overview.md
+++ b/docs/tests/overview.md
@@ -34,6 +34,7 @@ Objetivo: descrever a estratégia mínima de testes para o projeto, com foco em 
 ## Atualizações recentes
 - CategoryDetector: teste adicional cobrindo branches previamente não exercitados em `src/category_detector.py` (normalização vazia, mapeamentos custom e aprendizado a partir de arquivo salvo). Arquivo: `tests/unit/category/test_category_detector_additional_coverage.py`. Resultado: 100% no run focado.
 - DataCollector: teste unitário para o caminho de timeout na coleta concorrente, garantindo marcação de erro e atualização de estatísticas. Arquivo: `tests/unit/data_collector/test_data_collector_timeout_not_done.py`. Resultado: 100% no run focado.
+- TomadaTempo IT1 (Issue #105): integração mínima determinística do parser `sources/tomada_tempo.py` cobrindo caminho feliz, campos opcionais ausentes e HTML malformado com fallbacks (sem crash). Testes: `tests/integration/test_phase3_tomada_tempo_integration.py`, `tests/integration/test_phase3_tomada_tempo_parsing_variants.py`. Métricas recentes: ~48% de cobertura no run de integração; execuções estáveis (ex.: 23 passed, 3 skipped, 1 xfailed).
 
 ## Determinismo de ICS e snapshots
 - Ordenação de eventos: VEVENTs ordenados determinísticamente por `datetime` (convertido para UTC; fallback para naive) e, em seguida, por `display_name`/`name` para desempate.


### PR DESCRIPTION
Versão 0.5.22 — TomadaTempo IT1 (docs)

Alterações:
- CHANGELOG.md: adicionada seção 0.5.22 com escopo, cenários (happy/missing_fields/malformed_html) e sincronização de docs.
- RELEASES.md: inserida entrada "Versão 0.5.22" detalhando escopo, métricas e sincronização.
- docs/tests/overview.md: atualizada seção "Atualizações recentes" com IT1 e caminhos de teste.

Validação:
- pytest -m integration: 42 passed, 4 skipped, 1 xfailed; cobertura 50.99% (>=45%).
- XML/HTML de cobertura gerados com sucesso (coverage.xml, htmlcov/).

Rastreabilidade:
- Closes #105. Relacionado a PR #119.
- Bump de versão aplicado em src/__init__.py para 0.5.22.

Notas:
- Sem mudanças funcionais de runtime; alterações restritas à documentação e governança de release.