### PR TITLE
docs(tests): overview — remove seção duplicada e valida referências

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,37 @@ O formato é baseado em [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 e este projeto adere ao [Versionamento Semântico](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Nenhuma mudança registrada ainda.
+- ICS — Ordenação determinística reforçada
+  - `src/ical_generator.py`: adicionado critério final de desempate (`event_id`) na chave de ordenação em `ICalGenerator.generate_calendar` para garantir estabilidade absoluta quando `datetime`, `detected_category`, `display_name`/`name` e `source_priority` forem idênticos.
+  - Efeito: elimina variações residuais de ordem em empates, estabilizando VEVENTs no `.ics` em todos os cenários.
+- Testes/Docs — Limpeza de referência a xfail
+  - `tests/integration/test_phase2_dedupe_order_consistency.py`: removida menção desatualizada de que a checagem de ordenação é xfail; asserções permanecem ativas e determinísticas.
+  - Rastreabilidade: estabilização de ordenação ICS (removendo necessidade de xfail mencionado em comentários/docstring).
+  - Deduplicação — desempate determinístico no EventProcessor
+  - `src/event_processor.py`: em `_select_best_event`, adicionada chave final de desempate por `event_id` na ordenação de candidatos (após `source_priority`, contagem de `streaming_links`, tamanho de `name` e presença de `official_url`) para garantir estabilidade absoluta quando atributos principais empatam.
+  - Efeito: escolha do "melhor" evento torna-se estável entre execuções, evitando oscilação sutil em empates completos e refletindo de forma determinística na geração do `.ics` e nas estatísticas de processamento.
+- Docs/Tests — Atualização do overview de testes
+  - `docs/tests/overview.md`: removida seção duplicada "CI — Helper Make para PRs" e adicionada a subseção "Validação de referências (2025-08-20)".
+  - Ajuste de referências de testes citados no documento, confirmando arquivos existentes:
+    - CategoryDetector (unit): `tests/unit/category/test_category_detector_normalize_more.py`, `tests/unit/category/test_category_detector_threshold_and_learning.py`.
+    - DataCollector (unit): `tests/unit/data_collector/test_data_collector_basic.py`, `tests/unit/data_collector/test_data_collector_more.py`, `tests/unit/data_collector/test_data_collector_retry.py`.
+    - PayloadManager (integration): `tests/integration/test_phase2_payload_manager.py`.
+  - Referências inexistentes anteriores foram marcadas para correção futura no próprio documento, sem impacto na execução dos testes/CI.
+
+## [0.6.0] - 2025-08-20
+### Release — Publicação v0.6.0 (Release Drafter)
+
+- Consolida e publica as mudanças do ciclo anterior relacionadas ao retry por fonte no `DataCollector`.
+- Rastreabilidade: Issue #111 e PR #135 (fechados), artefatos arquivados em `docs/issues/closed/issue-111.{md,json}`.
+- Documentação sincronizada: `RELEASES.md` (seção "Versão 0.6.0"), `DATA_SOURCES.md`, `docs/CONFIGURATION_GUIDE.md`, `config/config.example.json`.
+- Versionamento: `src/__init__.py` atualizado para `0.6.0`.
+
+### Coletor — Retry por Fonte (Resumo)
+
+- Flags/chaves em `data_sources`: `retry_failed_sources`, `max_retries` (precedência sobre `retry_attempts` — legado) e `retry_backoff_seconds` (backoff linear).
+- Validação: `src/utils/config_validator.py::validate_data_sources_config` integrada via `src/config_manager.py` (normalização de tipos/valores ≥ 0).
+- Testes: `tests/unit/data_collector/test_data_collector_retry.py` cobrindo sucesso após retry e falha ao esgotar tentativas (determinístico).
+- Detalhes técnicos permanecem descritos na seção `[0.5.24]` abaixo.
 
 ## [0.5.24] - 2025-08-20
 ### CI/Tests — Cobertura por flags (ajuste unit/integration/e2e)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3,7 +3,40 @@
 Este arquivo contém um registro acumulativo de todas as versões lançadas do projeto, com notas detalhadas sobre as mudanças em cada versão.
 
 ## Não Lançado
-Sem notas no momento.
+ICS — Ordenação determinística reforçada
+
+- `src/ical_generator.py`: adicionado desempate final por `event_id` na chave de ordenação de eventos do iCal, garantindo estabilidade mesmo quando `datetime`/categoria/nome/prioridade de fonte forem idênticos.
+- Impacto: elimina variações residuais na ordem de VEVENTs no `.ics` em empates completos; snapshots mais estáveis.
+
+Testes/Docs — Limpeza de referência a xfail
+
+- `tests/integration/test_phase2_dedupe_order_consistency.py`: removida menção desatualizada de xfail na docstring; checagem de ordenação permanece ativa e determinística.
+- Documentos sincronizados: `CHANGELOG.md` (Unreleased) com a nota acima.
+
+Docs/Tests — Atualização do overview de testes
+
+- `docs/tests/overview.md`: removida seção duplicada "CI — Helper Make para PRs" e adicionada a subseção "Validação de referências (2025-08-20)".
+- Referências de arquivos de teste confirmadas e alinhadas ao estado atual do repositório:
+  - CategoryDetector (unit): `tests/unit/category/test_category_detector_normalize_more.py`, `tests/unit/category/test_category_detector_threshold_and_learning.py`.
+  - DataCollector (unit): `tests/unit/data_collector/test_data_collector_basic.py`, `tests/unit/data_collector/test_data_collector_more.py`, `tests/unit/data_collector/test_data_collector_retry.py`.
+  - PayloadManager (integration): `tests/integration/test_phase2_payload_manager.py`.
+- Referências inexistentes anteriores foram marcadas para correção futura diretamente no documento, sem impacto no CI.
+
+## Versão 0.6.0 (2025-08-20)
+
+Coletor — Retry por Fonte (Issue #111, PR #135)
+
+- Retry configurável por fonte ativado pela flag `retry_failed_sources`.
+- Novas chaves em `data_sources`:
+  - `retry_failed_sources` (boolean, padrão: `true`)
+  - `max_retries` (inteiro, padrão: `1`; precedência sobre `retry_attempts` — legado)
+  - `retry_backoff_seconds` (float, padrão: `0.5`)
+- Compatibilidade: `retry_attempts` (legado) permanece suportado como fallback quando `max_retries` não estiver presente.
+- Implementação: tratamento de exceções transitórias (`TimeoutError`, `OSError`, `IOError`) com backoff linear e contabilização por tentativa durante a coleta.
+- Validação: `src/utils/config_validator.py::validate_data_sources_config` normaliza as chaves acima e integra-se ao `ConfigManager`.
+- Documentação: `DATA_SOURCES.md`, `docs/CONFIGURATION_GUIDE.md` e `config/config.example.json` atualizados; `CHANGELOG.md` registra a mudança.
+- Testes: `tests/unit/data_collector/test_data_collector_retry.py` cobre sucesso após retry e falha ao esgotar tentativas, de forma determinística.
+- Rastreabilidade: issue #111 arquivada em `docs/issues/closed/issue-111.{md,json}`; release publicada via Release Drafter.
 
 ## Versão 0.5.24 (2025-08-20)
 CI/Tests — Cobertura por flags (ajuste unit/integration/e2e)


### PR DESCRIPTION
- Remove seção duplicada “CI — Helper Make para PRs” em docs/tests/overview.md\n- Adiciona “Validação de referências (2025-08-20)” com status dos arquivos\n- Atualiza CHANGELOG.md ([Unreleased]) e RELEASES.md (“Não Lançado”)\n- Referências confirmadas:\n  - CategoryDetector: tests/unit/category/test_category_detector_normalize_more.py, ...threshold_and_learning.py\n  - DataCollector: tests/unit/data_collector/test_data_collector_basic.py, ..._more.py, ..._retry.py\n  - PayloadManager: tests/integration/test_phase2_payload_manager.py\n\nNotas:\n- Mudança apenas documental; compatível com SemVer (patch).\n- Release Drafter agregará esta entrada em “Não Lançado”.