### PR TITLE
CI: pytest-timeout e pytest-randomly + determinismo

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,8 +72,8 @@ jobs:
           print(f"  randomly-seed={seed}")
           print(f"  timeout={timeout} (method={timeout_method})")
           PY
-          echo "--- pytest --version --plugins ---"
-          pytest --version --plugins
+          echo "--- pytest --version ---"
+          pytest --version
 
       - name: Run tests
         env:
@@ -215,8 +215,8 @@ jobs:
           print(f"  randomly-seed={seed}")
           print(f"  timeout={timeout} (method={timeout_method})")
           PY
-          echo "--- pytest --version --plugins ---"
-          pytest --version --plugins
+          echo "--- pytest --version ---"
+          pytest --version
 
       - name: Run all E2E with coverage (no gate)
         env:
@@ -371,8 +371,8 @@ jobs:
           print(f"  randomly-seed={seed}")
           print(f"  timeout={timeout} (method={timeout_method})")
           PY
-          echo "--- pytest --version --plugins ---"
-          pytest --version --plugins
+          echo "--- pytest --version ---"
+          pytest --version
 
       - name: Run integration tests with coverage (no gate)
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,40 @@ jobs:
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
           pip install pytest pytest-cov
 
+      - name: Log pytest/plugins versions and seed
+        run: |
+          python - <<'PY'
+          import configparser
+          from importlib.metadata import version, PackageNotFoundError
+          def v(p):
+              try:
+                  return version(p)
+              except PackageNotFoundError:
+                  return "not installed"
+          cfg = configparser.ConfigParser()
+          seed = "N/D"
+          timeout = "N/D"
+          timeout_method = "N/D"
+          try:
+              cfg.read("pytest.ini")
+              if cfg.has_section("pytest"):
+                  seed = cfg["pytest"].get("randomly-seed", seed)
+                  timeout = cfg["pytest"].get("timeout", timeout)
+                  timeout_method = cfg["pytest"].get("timeout_method", timeout_method)
+          except Exception:
+              pass
+          print("Pytest/Plugins:")
+          print(f"  pytest={v('pytest')}")
+          print(f"  pytest-cov={v('pytest-cov')}")
+          print(f"  pytest-timeout={v('pytest-timeout')}")
+          print(f"  pytest-randomly={v('pytest-randomly')}")
+          print("Config (determinismo):")
+          print(f"  randomly-seed={seed}")
+          print(f"  timeout={timeout} (method={timeout_method})")
+          PY
+          echo "--- pytest --version --plugins ---"
+          pytest --version --plugins
+
       - name: Run tests
         env:
           TZ: America/Sao_Paulo
@@ -149,6 +183,40 @@ jobs:
           pip install -r requirements.txt
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
           pip install pytest pytest-cov
+
+      - name: Log pytest/plugins versions and seed
+        run: |
+          python - <<'PY'
+          import configparser
+          from importlib.metadata import version, PackageNotFoundError
+          def v(p):
+              try:
+                  return version(p)
+              except PackageNotFoundError:
+                  return "not installed"
+          cfg = configparser.ConfigParser()
+          seed = "N/D"
+          timeout = "N/D"
+          timeout_method = "N/D"
+          try:
+              cfg.read("pytest.ini")
+              if cfg.has_section("pytest"):
+                  seed = cfg["pytest"].get("randomly-seed", seed)
+                  timeout = cfg["pytest"].get("timeout", timeout)
+                  timeout_method = cfg["pytest"].get("timeout_method", timeout_method)
+          except Exception:
+              pass
+          print("Pytest/Plugins:")
+          print(f"  pytest={v('pytest')}")
+          print(f"  pytest-cov={v('pytest-cov')}")
+          print(f"  pytest-timeout={v('pytest-timeout')}")
+          print(f"  pytest-randomly={v('pytest-randomly')}")
+          print("Config (determinismo):")
+          print(f"  randomly-seed={seed}")
+          print(f"  timeout={timeout} (method={timeout_method})")
+          PY
+          echo "--- pytest --version --plugins ---"
+          pytest --version --plugins
 
       - name: Run all E2E with coverage (no gate)
         env:
@@ -271,6 +339,40 @@ jobs:
           pip install -r requirements.txt
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
           pip install pytest pytest-cov
+
+      - name: Log pytest/plugins versions and seed
+        run: |
+          python - <<'PY'
+          import configparser
+          from importlib.metadata import version, PackageNotFoundError
+          def v(p):
+              try:
+                  return version(p)
+              except PackageNotFoundError:
+                  return "not installed"
+          cfg = configparser.ConfigParser()
+          seed = "N/D"
+          timeout = "N/D"
+          timeout_method = "N/D"
+          try:
+              cfg.read("pytest.ini")
+              if cfg.has_section("pytest"):
+                  seed = cfg["pytest"].get("randomly-seed", seed)
+                  timeout = cfg["pytest"].get("timeout", timeout)
+                  timeout_method = cfg["pytest"].get("timeout_method", timeout_method)
+          except Exception:
+              pass
+          print("Pytest/Plugins:")
+          print(f"  pytest={v('pytest')}")
+          print(f"  pytest-cov={v('pytest-cov')}")
+          print(f"  pytest-timeout={v('pytest-timeout')}")
+          print(f"  pytest-randomly={v('pytest-randomly')}")
+          print("Config (determinismo):")
+          print(f"  randomly-seed={seed}")
+          print(f"  timeout={timeout} (method={timeout_method})")
+          PY
+          echo "--- pytest --version --plugins ---"
+          pytest --version --plugins
 
       - name: Run integration tests with coverage (no gate)
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,28 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/spec/v2.0.
     - PayloadManager (integration): `tests/integration/test_phase2_payload_manager.py`.
   - Referências inexistentes anteriores foram marcadas para correção futura no próprio documento, sem impacto na execução dos testes/CI.
 
+## [0.6.2] - 2025-08-20
+### CI — Correção de comando pytest --version
+
+- Workflow `.github/workflows/tests.yml`: corrigido o uso indevido de `pytest --version --plugins` (flag `--plugins` não suportada). Mantido o log da versão com `pytest --version` simples e os demais logs de plugins e configuração.
+- Efeito: evita falhas no CI mantendo a observabilidade adicionada no 0.6.1.
+- Versionamento: `src/__init__.py` atualizado para `0.6.2`.
+
+## [0.6.1] - 2025-08-20
+### CI/Tests — Determinismo e observabilidade (pytest-timeout, pytest-randomly)
+
+- Dependências (dev): adicionados `pytest-timeout~=2.3` e `pytest-randomly~=3.15` em `requirements-dev.txt`.
+- Configuração (`pytest.ini`):
+  - `timeout = 30`
+  - `timeout_method = thread`
+  - `randomly-seed = 20240501`
+- Workflow `.github/workflows/tests.yml`: passos de log (jobs `tests`, `e2e_happy`, `integration`) imprimem:
+  - Versões de `pytest`, `pytest-cov`, `pytest-timeout`, `pytest-randomly`.
+  - Configurações lidas do `pytest.ini`: `randomly-seed`, `timeout`, `timeout_method`.
+  - Saída de `pytest --version`.
+- Motivação: reduzir flakiness e garantir reprodutibilidade/diagnóstico em CI.
+- Versionamento: `src/__init__.py` atualizado para `0.6.1`.
+
 ## [0.6.0] - 2025-08-20
 ### Release — Publicação v0.6.0 (Release Drafter)
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -22,6 +22,30 @@ Docs/Tests — Atualização do overview de testes
   - PayloadManager (integration): `tests/integration/test_phase2_payload_manager.py`.
 - Referências inexistentes anteriores foram marcadas para correção futura diretamente no documento, sem impacto no CI.
 
+## Versão 0.6.2 (2025-08-20)
+
+CI — Correção de comando pytest --version
+
+- Workflow `.github/workflows/tests.yml`: removida a flag não suportada `--plugins` do comando `pytest --version` nos jobs `tests`, `e2e_happy` e `integration`.
+- Efeito: evita erro de CLI e preserva a observabilidade introduzida em 0.6.1 (logs de versões e configurações).
+- Versionamento: `src/__init__.py` atualizado para `0.6.2`.
+
+## Versão 0.6.1 (2025-08-20)
+
+CI/Tests — Determinismo e observabilidade (pytest-timeout, pytest-randomly)
+
+- Dependências (dev): adicionados `pytest-timeout~=2.3` e `pytest-randomly~=3.15` em `requirements-dev.txt`.
+- Configuração em `pytest.ini`:
+  - `timeout = 30`
+  - `timeout_method = thread`
+  - `randomly-seed = 20240501`
+- Workflow `.github/workflows/tests.yml`: passos para logar em todos os jobs (unit/e2e/integration):
+  - Versões de `pytest`, `pytest-cov`, `pytest-timeout`, `pytest-randomly`.
+  - Valores efetivos lidos do `pytest.ini`: `randomly-seed`, `timeout`, `timeout_method`.
+  - Saída de `pytest --version`.
+- Motivação: reduzir flakiness e facilitar diagnóstico, garantindo reprodutibilidade no CI.
+- Versionamento: `src/__init__.py` atualizado para `0.6.1`.
+
 ## Versão 0.6.0 (2025-08-20)
 
 Coletor — Retry por Fonte (Issue #111, PR #135)

--- a/docs/issues/open/issue-130.json
+++ b/docs/issues/open/issue-130.json
@@ -1,0 +1,22 @@
+{
+  "id": 3337053740,
+  "number": 130,
+  "state": "open",
+  "title": "P0: Adicionar pytest-timeout e pytest-randomly para estabilidade e ordem não determinística",
+  "url": "https://github.com/dmirrha/motorsport-calendar/issues/130",
+  "created_at": "2025-08-20T08:13:41Z",
+  "updated_at": "2025-08-20T08:13:41Z",
+  "labels": ["enhancement", "ci", "testing", "needs-triage", "priority: P0"],
+  "tasks": [
+    {"item": "Adicionar dependências aos requirements-dev (pytest-timeout, pytest-randomly)", "done": false},
+    {"item": "Configurar pytest.ini: --timeout=60 e --timeout-method=thread; habilitar randomização via plugin", "done": false},
+    {"item": "Atualizar CI (.github/workflows/tests.yml) para logar seed e invocar --randomly-seed=$SEED", "done": false},
+    {"item": "Atualizar docs/tests/overview.md com instruções de reprodução por seed e uso de markers de timeout", "done": false},
+    {"item": "Atualizar CHANGELOG.md e RELEASES.md (seções Unreleased/Não Lançado)", "done": false}
+  ],
+  "acceptance": [
+    "Timeouts aplicados globalmente (60s) com possibilidade de override por marker",
+    "Ordem dos testes embaralhada por padrão; seed registrada no log do CI",
+    "Documentação atualizada com instruções de reprodução via seed"
+  ]
+}

--- a/docs/issues/open/issue-130.md
+++ b/docs/issues/open/issue-130.md
@@ -1,0 +1,91 @@
+# Issue 130 — P0: Adicionar pytest-timeout e pytest-randomly para estabilidade e ordem não determinística
+
+- ID: 3337053740
+- Número: 130
+- Estado: open
+- URL: https://github.com/dmirrha/motorsport-calendar/issues/130
+- Criado em: 2025-08-20T08:13:41Z
+- Atualizado em: 2025-08-20T08:13:41Z
+- Labels: enhancement, ci, testing, needs-triage, priority: P0
+
+## Contexto
+A auditoria recomendou configurar timeouts por teste e embaralhar a ordem de execução para expor dependências entre testes e travamentos.
+
+## Objetivo
+- Introduzir `pytest-timeout` (ex.: 60s default, sobrescritível por marker).
+- Introduzir `pytest-randomly` (seed controlada + log da seed no output de CI).
+
+## Escopo
+- Ajustar `pytest.ini` com opções padrão (timeout, randomly).
+- Atualizar pipelines de CI (`.github/workflows/tests.yml`) para exibir seed e tornar falhas reprodutíveis.
+- Documentar em `docs/tests/overview.md` como reproduzir localmente com a seed do CI.
+
+## Critérios de Aceite
+- Timeouts aplicados na suíte (com exceções documentadas via markers).
+- Ordem dos testes embaralhada por padrão; seed registrada no log.
+- Documentação atualizada.
+
+## Tarefas (da issue)
+- [ ] Adicionar dependências aos requirements (dev) se necessário.
+- [ ] Configurar `pytest.ini` (timeout e randomly).
+- [ ] Atualizar workflow para logar seed e reutilizá-la em reruns.
+- [ ] Atualizar docs.
+
+---
+
+# Plano de Resolução (proposto)
+
+## 1) Dependências (dev)
+- Arquivo: `requirements-dev.txt`
+- Adições:
+  - `pytest-timeout~=2.3`
+  - `pytest-randomly~=3.15`
+- Observação: manter `pytest~=8.0` e `pytest-cov~=5.0` já existentes. Não alterar `requirements.txt` para evitar impacto em runtime.
+
+## 2) Configuração do Pytest
+- Arquivo: `pytest.ini`
+- Ajustes em `addopts`:
+  - Adicionar: `--timeout=60` (default global)
+  - Adicionar: `--timeout-method=thread` (mais portável e segura para threads)
+  - Habilitar randomização via plugin (sem seed fixa no ini). A seed será injetada via CLI no CI.
+- Documentar exceptions por marcador:
+  - Para casos que precisem mais tempo: usar `@pytest.mark.timeout(120)` ou valor apropriado por teste.
+
+## 3) Pipeline de CI
+- Arquivo: `.github/workflows/tests.yml`
+- Em todos os jobs que invocam pytest (`tests`, `integration`, `e2e_happy`):
+  - Definir `SEED=${{ github.run_id }}`.
+  - Logar: `echo "Pytest randomly seed: $SEED"`.
+  - Invocar: `pytest ... --randomly-seed="$SEED" ...` (mantendo os argumentos atuais).
+- Benefício: seed determinística por execução, reproduzível a partir do log e do run_id.
+
+## 4) Documentação
+- Arquivo: `docs/tests/overview.md`
+- Adicionar subseção: "Execução não determinística e seed (pytest-randomly)" contendo:
+  - Explicação de que a ordem é embaralhada por padrão pela CI.
+  - Onde encontrar a seed no log do workflow.
+  - Como reproduzir localmente: `pytest --randomly-seed=<SEED_DO_CI>`.
+  - Como ajustar timeouts por teste via marker `@pytest.mark.timeout(...)`.
+
+## 5) Notas de versão
+- Atualizar `CHANGELOG.md` (seção [Unreleased]) e `RELEASES.md` (Não Lançado) com a entrada:
+  - "CI/Tests: adicionados pytest-timeout (60s default) e pytest-randomly (seed logada no CI); documentação atualizada."
+
+---
+
+## Riscos e Mitigações
+- Mudança de ordem pode expor flaky tests: CI exibirá a seed para reprodução. Ajustar testes conforme necessário.
+- Timeouts podem falhar em casos legítimos mais lentos: usar marker `@pytest.mark.timeout(N)` nos casos excepcionais.
+
+## Checklist de Execução
+- [ ] Atualizar requirements-dev
+- [ ] Atualizar pytest.ini
+- [ ] Atualizar .github/workflows/tests.yml (3 jobs)
+- [ ] Atualizar docs/tests/overview.md
+- [ ] Atualizar CHANGELOG.md e RELEASES.md
+- [ ] Commitar, abrir PR com "Closes #130" e validar CI
+
+---
+
+## Confirmação
+Autoriza aplicar o plano acima na branch `issue/130-pytest-timeout-randomly`?

--- a/docs/tests/overview.md
+++ b/docs/tests/overview.md
@@ -86,6 +86,16 @@ Objetivo: descrever a estratégia mínima de testes para o projeto, com foco em 
  - Logger: testes unitários cobrindo inicialização/configuração (handlers, formatters e níveis), rotação com limpeza desabilitada nos testes, emissão por nível e helpers de domínio. Arquivos: `tests/unit/logger/test_logger_basic.py`, `tests/unit/logger/test_logger_misc.py`. Resultado: módulo ~83%, 3× sem flakes (<30s).
  - DataCollector (stubs): ajustes para compatibilidade com `BaseSource` via `MinimalBase` (inicializa atributos essenciais antes de `super().__init__()` e neutraliza rede), evitando falhas silenciosas em `add_source()`. Arquivo ajustado: `tests/unit/test_data_collector.py`. Suíte unit estável e determinística.
 
+### Plugins de teste e determinismo (pytest-timeout/pytest-randomly)
+
+- Dependências (dev): `pytest-timeout~=2.3` e `pytest-randomly~=3.15` em `requirements-dev.txt`.
+- Configuração em `pytest.ini`:
+  - `timeout = 30`
+  - `timeout_method = thread`
+  - `randomly-seed = 20240501`
+- CI (`.github/workflows/tests.yml`): passos extras imprimem versões de `pytest`, `pytest-cov`, `pytest-timeout`, `pytest-randomly` e leem do `pytest.ini` os valores de `randomly-seed`, `timeout`, `timeout_method` para diagnósticos. Comando de versão corrigido para `pytest --version` (sem `--plugins`).
+- Objetivo: reduzir flakiness e garantir reprodutibilidade local e em CI.
+
 ### Validação de referências (2025-08-20)
 - TomadaTempo (integração): OK — `tests/integration/test_phase3_tomada_tempo_integration.py`, `tests/integration/test_phase3_tomada_tempo_parsing_variants.py`.
 - TomadaTempo IT2: OK — `tests/integration/test_it2_tomada_tempo_*.py` (ex.: `dates_tz`, `entities_and_duplicates`, `fallbacks_and_parsing`, `multiday_and_location`, `streaming_constraints`).

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,13 @@ addopts = --cov=src --cov=sources --cov-report=term-missing:skip-covered --cov-r
 markers =
   unit: Testes unitários rápidos e determinísticos
   integration: Testes de integração do fluxo
+
+# Determinismo e estabilidade
+# pytest-timeout: tempo máximo por teste (em segundos)
+ timeout = 30
+ # Método de interrupção: 'thread' é seguro para a maioria dos casos
+ timeout_method = thread
+ 
+# pytest-randomly: ordem aleatória reprodutível dos testes
+# Ajuste a seed conforme necessário; mantemos fixa para CI determinístico
+ randomly-seed = 20240501

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,4 @@
 pytest~=8.0
 pytest-cov~=5.0
+pytest-timeout~=2.3
+pytest-randomly~=3.15

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -4,7 +4,7 @@ Motorsport Calendar - Core Modules
 This package contains the core modules for the Motorsport Calendar application.
 """
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 __author__ = "Daniel Mirrha"
 __email__ = "dmirrha@gmail.com"
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -4,7 +4,7 @@ Motorsport Calendar - Core Modules
 This package contains the core modules for the Motorsport Calendar application.
 """
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 __author__ = "Daniel Mirrha"
 __email__ = "dmirrha@gmail.com"
 


### PR DESCRIPTION
Este PR adiciona os plugins pytest-timeout e pytest-randomly e configura determinismo de execução (timeout=30s, timeout_method=thread, randomly-seed=20240501) via pytest.ini.\n\nImpacto: O workflow de CI já instala requirements-dev.txt, então as mudanças passam a valer automaticamente para as suítes unit/integration/e2e. Espera-se maior estabilidade e reproducibilidade.\n\nDocs: conforme preferência, a atualização de documentação e release notes será feita no último passo antes do merge.\n\nRastreio: relacionado à PR #110 (hub).