### PR TITLE
CI: Codecov patch gate ≥85% (informational)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,6 +6,7 @@ coverage:
     patch:
       default:
         informational: true
+        target: 85%
 comment: false
 flags:
   unit: {}

--- a/docs/issues/open/issue-131.json
+++ b/docs/issues/open/issue-131.json
@@ -28,10 +28,15 @@
     }
   },
   "tasks": [
-    {"item": "Ajustar codecov.yml (patch.default.target: 85%, informational: true)", "done": false},
+    {"item": "Ajustar codecov.yml (patch.default.target: 85%, informational: true)", "done": true},
     {"item": "Validar check do Codecov em PR de teste", "done": false},
     {"item": "Atualizar README.md e docs/tests/overview.md com instruções", "done": false}
   ],
+  "docs_updated": [
+    "docs/issues/open/issue-131.md",
+    "docs/issues/open/issue-131.json"
+  ],
+  "pr": 140,
   "acceptance": [
     "Check de patch aparece nos PRs com target de 85%",
     "Não bloqueia merges (informational: true)",

--- a/docs/issues/open/issue-131.json
+++ b/docs/issues/open/issue-131.json
@@ -1,0 +1,40 @@
+{
+  "id": 3337053812,
+  "number": 131,
+  "state": "open",
+  "title": "P0: Habilitar gate de cobertura de patch (≥85%) no Codecov (modo informativo)",
+  "milestone": null,
+  "epic": null,
+  "url": "https://github.com/dmirrha/motorsport-calendar/issues/131",
+  "created_at": "2025-08-20T08:13:43Z",
+  "updated_at": "2025-08-20T08:13:43Z",
+  "labels": ["enhancement", "ci", "coverage", "needs-triage", "priority: P0"],
+  "plan": {
+    "config_file": "codecov.yml",
+    "coverage": {
+      "status": {
+        "patch": {
+          "default": {
+            "informational": true,
+            "target": "85%"
+          }
+        },
+        "project": {
+          "default": {
+            "informational": true
+          }
+        }
+      }
+    }
+  },
+  "tasks": [
+    {"item": "Ajustar codecov.yml (patch.default.target: 85%, informational: true)", "done": false},
+    {"item": "Validar check do Codecov em PR de teste", "done": false},
+    {"item": "Atualizar README.md e docs/tests/overview.md com instruções", "done": false}
+  ],
+  "acceptance": [
+    "Check de patch aparece nos PRs com target de 85%",
+    "Não bloqueia merges (informational: true)",
+    "Documentação atualizada (README/overview)"
+  ]
+}

--- a/docs/issues/open/issue-131.md
+++ b/docs/issues/open/issue-131.md
@@ -25,7 +25,7 @@ Configurar `codecov.yml` para ativar o status de `patch` com limiar ≥85% em mo
 - Documentação atualizada.
 
 ## Tarefas (da issue)
-- [ ] Ajustar `codecov.yml`.
+- [x] Ajustar `codecov.yml`.
 - [ ] Validar em PR de teste.
 - [ ] Atualizar docs.
 
@@ -57,13 +57,16 @@ Configurar `codecov.yml` para ativar o status de `patch` com limiar ≥85% em mo
 - Ruído inicial em PRs: manter “informational” até estabilizar o processo, depois avaliar tornar required.
 
 ## Checklist de Execução
-- [ ] Atualizar `codecov.yml` (target 85% em `coverage.status.patch.default`).
+- [x] Atualizar `codecov.yml` (target 85% em `coverage.status.patch.default`).
 - [ ] Abrir PR e validar check do Codecov (patch ≥85%).
 - [ ] Atualizar `README.md` e `docs/tests/overview.md` com instruções de interpretação.
 - [ ] Atualizar `CHANGELOG.md` e `RELEASES.md`.
 - [ ] PR com “Closes #131” e CI verde.
 
 ---
+
+## Status
+- PR aberta: #140 — https://github.com/dmirrha/motorsport-calendar/pull/140
 
 ## Confirmação
 Autoriza aplicar o plano acima na branch `issue/131-codecov-patch-gate-85` (editar `codecov.yml` e abrir PR de validação)?

--- a/docs/issues/open/issue-131.md
+++ b/docs/issues/open/issue-131.md
@@ -1,0 +1,69 @@
+# Issue 131 — P0: Habilitar gate de cobertura de patch (≥85%) no Codecov (informativo)
+
+- ID: 3337053812
+- Número: 131
+- Estado: open
+- URL: https://github.com/dmirrha/motorsport-calendar/issues/131
+- Criado em: 2025-08-20T08:13:43Z
+- Atualizado em: 2025-08-20T08:13:43Z
+- Labels: enhancement, ci, coverage, needs-triage, priority: P0
+
+## Contexto
+A auditoria destacou a necessidade de gate para cobertura de patch. Etapa inicial deve ser informativa para maturar o processo.
+
+## Objetivo
+Configurar `codecov.yml` para ativar o status de `patch` com limiar ≥85% em modo informativo (sem bloquear merges inicialmente).
+
+## Escopo
+- Atualizar `codecov.yml`: seção `coverage.status.patch` com `informational: true`, `target: 85%`.
+- Validar no CI que o status aparece nos PRs.
+- Documentar no README/overview como interpretar os checks.
+
+## Critérios de Aceite
+- Check de `patch` aparece nos PRs com target de 85%.
+- Não bloqueia merges nesta fase (informational true).
+- Documentação atualizada.
+
+## Tarefas (da issue)
+- [ ] Ajustar `codecov.yml`.
+- [ ] Validar em PR de teste.
+- [ ] Atualizar docs.
+
+---
+
+# Plano de Resolução (proposto)
+
+## 1) Configuração do Codecov
+- Arquivo: `codecov.yml`
+- Ajustar a seção `coverage.status.patch.default` para:
+  - `informational: true` (já presente)
+  - `target: 85%` (novo)
+- Manter `coverage.status.project.default.informational: true` como está.
+
+## 2) Validação em PR
+- Abrir PR de teste tocando um arquivo leve (ex.: doc) para acionar o Codecov.
+- Confirmar que o check “patch” aparece com target 85% e status informativo.
+
+## 3) Documentação
+- Arquivos: `README.md` e `docs/tests/overview.md`
+- Adicionar uma subseção “Gate de cobertura de patch (Codecov)” explicando:
+  - O que é “patch coverage” e o limiar de 85%.
+  - Que o check é informativo nesta fase (não bloqueia).
+  - Como interpretar o relatório do Codecov no PR.
+- Notas de versão: `CHANGELOG.md` e `RELEASES.md` (marcar como patch release; coordenação com PR #110 para consolidar doc no último passo antes do merge).
+
+## 4) Riscos e Mitigações
+- Flutuação de cobertura em patches pequenos: documentar limites e ajustar futuramente (ex.: `threshold`).
+- Ruído inicial em PRs: manter “informational” até estabilizar o processo, depois avaliar tornar required.
+
+## Checklist de Execução
+- [ ] Atualizar `codecov.yml` (target 85% em `coverage.status.patch.default`).
+- [ ] Abrir PR e validar check do Codecov (patch ≥85%).
+- [ ] Atualizar `README.md` e `docs/tests/overview.md` com instruções de interpretação.
+- [ ] Atualizar `CHANGELOG.md` e `RELEASES.md`.
+- [ ] PR com “Closes #131” e CI verde.
+
+---
+
+## Confirmação
+Autoriza aplicar o plano acima na branch `issue/131-codecov-patch-gate-85` (editar `codecov.yml` e abrir PR de validação)?


### PR DESCRIPTION
Ativa o gate de cobertura de patch no Codecov com alvo de 85% em modo informativo.

- Arquivo: `codecov.yml`
- Alteração: `coverage.status.patch.default.target: 85%` (mantendo `informational: true`)
- Efeito: adiciona o check `codecov/patch` nos PRs, sem bloquear merges nesta fase.

Notas:
- Documentação em `README.md` e `docs/tests/overview.md` será atualizada no último passo antes do merge, coordenada com a PR #110 (hub de docs).

Closes #131