### PR TITLE
CI: Flaky Nightly — job noturno para detecção de flaky tests

### DIFF
--- a/.github/workflows/flaky-nightly.yml
+++ b/.github/workflows/flaky-nightly.yml
@@ -1,0 +1,263 @@
+name: Flaky Nightly
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+    inputs:
+      iterations:
+        description: 'Número de iterações da suíte'
+        type: number
+        default: 6
+      timeout_seconds:
+        description: 'Timeout por teste (segundos)'
+        type: number
+        default: 60
+
+concurrency:
+  group: flaky-nightly-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  flaky:
+    name: Detect flaky tests (nightly)
+    # Executa no agendamento apenas no branch default (ex.: main). Manual roda em qualquer branch.
+    if: ${{ github.event_name != 'schedule' || github.ref_name == 'main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      ITERATIONS: ${{ inputs.iterations || 6 }}
+      TIMEOUT: ${{ inputs.timeout_seconds || 60 }}
+      TZ: America/Sao_Paulo
+    steps:
+      - name: Checkout
+      
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+          pip install pytest pytest-cov
+
+      - name: Log pytest/plugins versions and seed base
+        run: |
+          python - <<'PY'
+          import configparser
+          from importlib.metadata import version, PackageNotFoundError
+          def v(p):
+              try:
+                  return version(p)
+              except PackageNotFoundError:
+                  return "not installed"
+          cfg = configparser.ConfigParser()
+          seed = "N/D"
+          timeout = "N/D"
+          timeout_method = "N/D"
+          try:
+              cfg.read("pytest.ini")
+              if cfg.has_section("pytest"):
+                  seed = cfg["pytest"].get("randomly-seed", seed)
+                  timeout = cfg["pytest"].get("timeout", timeout)
+                  timeout_method = cfg["pytest"].get("timeout_method", timeout_method)
+          except Exception:
+              pass
+          print("Pytest/Plugins:")
+          print(f"  pytest={v('pytest')}")
+          print(f"  pytest-cov={v('pytest-cov')}")
+          print(f"  pytest-timeout={v('pytest-timeout')}")
+          print(f"  pytest-randomly={v('pytest-randomly')}")
+          print("Config (determinismo):")
+          print(f"  randomly-seed={seed}")
+          print(f"  timeout={timeout} (method={timeout_method})")
+          PY
+          echo "--- pytest --version ---"
+          pytest --version
+
+      - name: Run test suite multiple times (do not fail job)
+        shell: bash
+        run: |
+          set -e
+          ROOT="reports/gha/run_${{ github.run_id }}"
+          echo "Run root: $ROOT"
+          mkdir -p "$ROOT"
+          echo "ITERATIONS=${ITERATIONS}, TIMEOUT=${TIMEOUT}"
+          FAILURES=0
+          for i in $(seq 1 ${ITERATIONS}); do
+            echo "=== Iteration $i/${ITERATIONS} ==="
+            ITER_DIR="$ROOT/iter_${i}"
+            mkdir -p "$ITER_DIR"
+            JUNIT="$ITER_DIR/junit.xml"
+            LOG="$ITER_DIR/pytest.log"
+            SEED=$(( ( ( ${{ github.run_id }} + i ) % 100000 ) + 1 ))
+            echo "Seed=${SEED}" | tee "$ITER_DIR/seed.txt"
+            set +e
+            pytest -q -rA \
+              --durations=25 \
+              --timeout=${TIMEOUT} \
+              --junitxml="${JUNIT}" \
+              -o junit_family=legacy \
+              --randomly-seed=${SEED} \
+              2>&1 | tee "${LOG}"
+            EC=${PIPESTATUS[0]}
+            echo "exit_code=${EC}" | tee "$ITER_DIR/status.txt"
+            if [ $EC -ne 0 ]; then
+              echo "Iteration $i: failures occurred (exit=${EC})."
+              FAILURES=$((FAILURES+1))
+            fi
+            set -e
+          done
+          echo "Total iterations with failures: ${FAILURES}" | tee "$ROOT/summary/iterations_failures.txt"
+
+      - name: Consolidate JUnit results into CSV/JSON/MD
+        if: always()
+        run: |
+          python - <<'PY'
+          import os, glob, csv, json, xml.etree.ElementTree as ET
+          from datetime import datetime, timezone
+
+          run_id = os.getenv('GITHUB_RUN_ID', 'local')
+          root = f"reports/gha/run_{run_id}"
+          summary_dir = os.path.join(root, "summary")
+          os.makedirs(summary_dir, exist_ok=True)
+
+          junit_files = sorted(glob.glob(os.path.join(root, 'iter_*', 'junit.xml')))
+          agg = {}
+          total_cases = 0
+
+          def testcase_outcome(tc):
+            if tc.find('skipped') is not None:
+              return 'skipped'
+            if tc.find('failure') is not None or tc.find('error') is not None:
+              return 'failed'
+            return 'passed'
+
+          for jf in junit_files:
+            try:
+              tree = ET.parse(jf)
+              root_xml = tree.getroot()
+            except Exception:
+              continue
+            suites = [root_xml] if root_xml.tag == 'testsuite' else root_xml.findall('.//testsuite')
+            for s in suites:
+              for tc in s.findall('testcase'):
+                name = tc.attrib.get('name', '')
+                cls = tc.attrib.get('classname', '')
+                file = tc.attrib.get('file', '')
+                nodeid = f"{cls}::{name}" if cls else name
+                if file:
+                  nodeid = f"{file}::{nodeid}"
+                out = testcase_outcome(tc)
+                rec = agg.setdefault(nodeid, {"runs":0, "passes":0, "fails":0, "errors":0, "skips":0})
+                rec["runs"] += 1
+                if out == 'passed':
+                  rec["passes"] += 1
+                elif out == 'skipped':
+                  rec["skips"] += 1
+                else:
+                  # não distinguimos failure vs error com precisão do JUnit simplificado acima
+                  rec["fails"] += 1
+                total_cases += 1
+
+          items = []
+          for nodeid, m in agg.items():
+            runs = m["runs"] or 1
+            fails = m["fails"] + m["errors"]
+            passes = m["passes"]
+            skips = m["skips"]
+            flaky = passes > 0 and fails > 0
+            fail_rate = round(fails / runs, 4)
+            items.append({
+              "nodeid": nodeid,
+              "runs": runs,
+              "passes": passes,
+              "fails": m["fails"],
+              "errors": m["errors"],
+              "skips": skips,
+              "flaky": flaky,
+              "fail_rate": fail_rate,
+            })
+
+          items.sort(key=lambda x: (not x["flaky"], -x["fail_rate"], -x["runs"], x["nodeid"]))
+          flaky_count = sum(1 for x in items if x["flaky"]) if items else 0
+
+          csv_path = os.path.join(summary_dir, 'flaky_summary.csv')
+          with open(csv_path, 'w', newline='', encoding='utf-8') as f:
+            w = csv.DictWriter(f, fieldnames=["nodeid","runs","passes","fails","errors","skips","flaky","fail_rate"])
+            w.writeheader(); w.writerows(items)
+
+          json_path = os.path.join(summary_dir, 'flaky_summary.json')
+          with open(json_path, 'w', encoding='utf-8') as f:
+            json.dump({
+              "generated_at": datetime.now(timezone.utc).isoformat(),
+              "run_id": run_id,
+              "junit_files": junit_files,
+              "total_cases": total_cases,
+              "tests": items,
+              "flaky_count": flaky_count,
+            }, f, ensure_ascii=False, indent=2)
+
+          top = [x for x in items if x["flaky"]][:20]
+          md_path = os.path.join(summary_dir, 'summary.md')
+          with open(md_path, 'w', encoding='utf-8') as f:
+            f.write("# Flaky Nightly — Resumo\n\n")
+            f.write(f"- Total de testcases agregados: {len(items)}\n")
+            f.write(f"- Total de entradas JUnit: {len(junit_files)}\n")
+            f.write(f"- Testes marcados como flaky: {flaky_count}\n\n")
+            f.write("## Top 20 flaky (por taxa de falha)\n\n")
+            if not top:
+              f.write("Nenhum teste considerado flaky nesta execução.\n")
+            else:
+              f.write("| nodeid | runs | passes | fails | skips | fail_rate |\n")
+              f.write("|---|---:|---:|---:|---:|---:|\n")
+              for x in top:
+                f.write(f"| {x['nodeid']} | {x['runs']} | {x['passes']} | {x['fails']} | {x['skips']} | {x['fail_rate']:.2%} |\n")
+          print(f"Resumo gerado em: {summary_dir}")
+          PY
+
+      - name: Mirror summary to latest_main (default branch only)
+        if: ${{ always() && github.ref_name == 'main' }}
+        run: |
+          ROOT="reports/gha/run_${{ github.run_id }}"
+          mkdir -p reports/gha/latest_main/
+          cp -r "$ROOT/summary" reports/gha/latest_main/
+
+      - name: Upload artifacts (reports/gha)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: flaky-nightly-${{ github.run_id }}
+          path: |
+            reports/gha/
+          retention-days: 14
+
+      - name: Job summary
+        if: always()
+        run: |
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          echo "Flaky Nightly — Relatório" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- Execução: ${RUN_URL}" >> $GITHUB_STEP_SUMMARY
+          echo "- Artefato: flaky-nightly-${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ -f "reports/gha/run_${{ github.run_id }}/summary/summary.md" ]; then
+            echo "## Resumo" >> $GITHUB_STEP_SUMMARY
+            cat "reports/gha/run_${{ github.run_id }}/summary/summary.md" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "Resumo não encontrado." >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/flaky-nightly.yml
+++ b/.github/workflows/flaky-nightly.yml
@@ -122,6 +122,7 @@ jobs:
             fi
             set -e
           done
+          mkdir -p "$ROOT/summary"
           echo "Total iterations with failures: ${FAILURES}" | tee "$ROOT/summary/iterations_failures.txt"
 
       - name: Consolidate JUnit results into CSV/JSON/MD

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,6 +6,7 @@ coverage:
     patch:
       default:
         informational: true
+        target: 85%
 comment: false
 flags:
   unit: {}

--- a/docs/issues/open/issue-131.json
+++ b/docs/issues/open/issue-131.json
@@ -28,10 +28,15 @@
     }
   },
   "tasks": [
-    {"item": "Ajustar codecov.yml (patch.default.target: 85%, informational: true)", "done": false},
+    {"item": "Ajustar codecov.yml (patch.default.target: 85%, informational: true)", "done": true},
     {"item": "Validar check do Codecov em PR de teste", "done": false},
     {"item": "Atualizar README.md e docs/tests/overview.md com instruções", "done": false}
   ],
+  "docs_updated": [
+    "docs/issues/open/issue-131.md",
+    "docs/issues/open/issue-131.json"
+  ],
+  "pr": 140,
   "acceptance": [
     "Check de patch aparece nos PRs com target de 85%",
     "Não bloqueia merges (informational: true)",

--- a/docs/issues/open/issue-131.json
+++ b/docs/issues/open/issue-131.json
@@ -1,0 +1,40 @@
+{
+  "id": 3337053812,
+  "number": 131,
+  "state": "open",
+  "title": "P0: Habilitar gate de cobertura de patch (≥85%) no Codecov (modo informativo)",
+  "milestone": null,
+  "epic": null,
+  "url": "https://github.com/dmirrha/motorsport-calendar/issues/131",
+  "created_at": "2025-08-20T08:13:43Z",
+  "updated_at": "2025-08-20T08:13:43Z",
+  "labels": ["enhancement", "ci", "coverage", "needs-triage", "priority: P0"],
+  "plan": {
+    "config_file": "codecov.yml",
+    "coverage": {
+      "status": {
+        "patch": {
+          "default": {
+            "informational": true,
+            "target": "85%"
+          }
+        },
+        "project": {
+          "default": {
+            "informational": true
+          }
+        }
+      }
+    }
+  },
+  "tasks": [
+    {"item": "Ajustar codecov.yml (patch.default.target: 85%, informational: true)", "done": false},
+    {"item": "Validar check do Codecov em PR de teste", "done": false},
+    {"item": "Atualizar README.md e docs/tests/overview.md com instruções", "done": false}
+  ],
+  "acceptance": [
+    "Check de patch aparece nos PRs com target de 85%",
+    "Não bloqueia merges (informational: true)",
+    "Documentação atualizada (README/overview)"
+  ]
+}

--- a/docs/issues/open/issue-131.md
+++ b/docs/issues/open/issue-131.md
@@ -25,7 +25,7 @@ Configurar `codecov.yml` para ativar o status de `patch` com limiar ≥85% em mo
 - Documentação atualizada.
 
 ## Tarefas (da issue)
-- [ ] Ajustar `codecov.yml`.
+- [x] Ajustar `codecov.yml`.
 - [ ] Validar em PR de teste.
 - [ ] Atualizar docs.
 
@@ -57,13 +57,16 @@ Configurar `codecov.yml` para ativar o status de `patch` com limiar ≥85% em mo
 - Ruído inicial em PRs: manter “informational” até estabilizar o processo, depois avaliar tornar required.
 
 ## Checklist de Execução
-- [ ] Atualizar `codecov.yml` (target 85% em `coverage.status.patch.default`).
+- [x] Atualizar `codecov.yml` (target 85% em `coverage.status.patch.default`).
 - [ ] Abrir PR e validar check do Codecov (patch ≥85%).
 - [ ] Atualizar `README.md` e `docs/tests/overview.md` com instruções de interpretação.
 - [ ] Atualizar `CHANGELOG.md` e `RELEASES.md`.
 - [ ] PR com “Closes #131” e CI verde.
 
 ---
+
+## Status
+- PR aberta: #140 — https://github.com/dmirrha/motorsport-calendar/pull/140
 
 ## Confirmação
 Autoriza aplicar o plano acima na branch `issue/131-codecov-patch-gate-85` (editar `codecov.yml` e abrir PR de validação)?

--- a/docs/issues/open/issue-131.md
+++ b/docs/issues/open/issue-131.md
@@ -1,0 +1,69 @@
+# Issue 131 — P0: Habilitar gate de cobertura de patch (≥85%) no Codecov (informativo)
+
+- ID: 3337053812
+- Número: 131
+- Estado: open
+- URL: https://github.com/dmirrha/motorsport-calendar/issues/131
+- Criado em: 2025-08-20T08:13:43Z
+- Atualizado em: 2025-08-20T08:13:43Z
+- Labels: enhancement, ci, coverage, needs-triage, priority: P0
+
+## Contexto
+A auditoria destacou a necessidade de gate para cobertura de patch. Etapa inicial deve ser informativa para maturar o processo.
+
+## Objetivo
+Configurar `codecov.yml` para ativar o status de `patch` com limiar ≥85% em modo informativo (sem bloquear merges inicialmente).
+
+## Escopo
+- Atualizar `codecov.yml`: seção `coverage.status.patch` com `informational: true`, `target: 85%`.
+- Validar no CI que o status aparece nos PRs.
+- Documentar no README/overview como interpretar os checks.
+
+## Critérios de Aceite
+- Check de `patch` aparece nos PRs com target de 85%.
+- Não bloqueia merges nesta fase (informational true).
+- Documentação atualizada.
+
+## Tarefas (da issue)
+- [ ] Ajustar `codecov.yml`.
+- [ ] Validar em PR de teste.
+- [ ] Atualizar docs.
+
+---
+
+# Plano de Resolução (proposto)
+
+## 1) Configuração do Codecov
+- Arquivo: `codecov.yml`
+- Ajustar a seção `coverage.status.patch.default` para:
+  - `informational: true` (já presente)
+  - `target: 85%` (novo)
+- Manter `coverage.status.project.default.informational: true` como está.
+
+## 2) Validação em PR
+- Abrir PR de teste tocando um arquivo leve (ex.: doc) para acionar o Codecov.
+- Confirmar que o check “patch” aparece com target 85% e status informativo.
+
+## 3) Documentação
+- Arquivos: `README.md` e `docs/tests/overview.md`
+- Adicionar uma subseção “Gate de cobertura de patch (Codecov)” explicando:
+  - O que é “patch coverage” e o limiar de 85%.
+  - Que o check é informativo nesta fase (não bloqueia).
+  - Como interpretar o relatório do Codecov no PR.
+- Notas de versão: `CHANGELOG.md` e `RELEASES.md` (marcar como patch release; coordenação com PR #110 para consolidar doc no último passo antes do merge).
+
+## 4) Riscos e Mitigações
+- Flutuação de cobertura em patches pequenos: documentar limites e ajustar futuramente (ex.: `threshold`).
+- Ruído inicial em PRs: manter “informational” até estabilizar o processo, depois avaliar tornar required.
+
+## Checklist de Execução
+- [ ] Atualizar `codecov.yml` (target 85% em `coverage.status.patch.default`).
+- [ ] Abrir PR e validar check do Codecov (patch ≥85%).
+- [ ] Atualizar `README.md` e `docs/tests/overview.md` com instruções de interpretação.
+- [ ] Atualizar `CHANGELOG.md` e `RELEASES.md`.
+- [ ] PR com “Closes #131” e CI verde.
+
+---
+
+## Confirmação
+Autoriza aplicar o plano acima na branch `issue/131-codecov-patch-gate-85` (editar `codecov.yml` e abrir PR de validação)?

--- a/docs/issues/open/issue-132.json
+++ b/docs/issues/open/issue-132.json
@@ -1,0 +1,45 @@
+{
+  "id": 3337053877,
+  "number": 132,
+  "state": "open",
+  "title": "P0: Job noturno para detecção de flaky tests com múltiplas execuções",
+  "milestone": null,
+  "epic": null,
+  "url": "https://github.com/dmirrha/motorsport-calendar/issues/132",
+  "created_at": "2025-08-20T08:13:45Z",
+  "updated_at": "2025-08-20T08:13:45Z",
+  "labels": ["enhancement", "ci", "testing", "needs-triage", "priority: P0"],
+  "plan": {
+    "workflow_file": ".github/workflows/flaky-nightly.yml",
+    "schedule_cron": "0 3 * * *",
+    "iterations": 6,
+    "pytest_opts": "-q -rA --timeout=60 --durations=25",
+    "plugins": ["pytest-timeout", "pytest-randomly"],
+    "outputs": {
+      "per_iteration": ["junit.xml", "pytest.log"],
+      "consolidated": ["flaky_summary.csv", "flaky_summary.json", "summary.md"],
+      "artifact_root": "reports/gha/run_${{ github.run_id }}/",
+      "latest_main_mirror": "reports/gha/latest_main/"
+    }
+  },
+  "tasks": [
+    {"item": "Criar workflow agendado com suporte manual", "done": false},
+    {"item": "Executar suíte em N iterações e coletar JUnit/logs", "done": false},
+    {"item": "Consolidar métricas CSV/JSON e gerar summary.md", "done": false},
+    {"item": "Upload de artefatos e resumo no GITHUB_STEP_SUMMARY", "done": false},
+    {"item": "Atualizar documentação e release notes", "done": false},
+    {"item": "Criar arquivos de rastreabilidade (md/json)", "done": true}
+  ],
+  "docs_updated": [
+    "docs/issues/open/issue-132.md",
+    "docs/issues/open/issue-132.json"
+  ],
+  "pr": null,
+  "acceptance": [
+    "Workflow roda via cron diário (03:00 UTC) e manual",
+    "Artefatos por iteração e consolidados disponíveis para download",
+    "Relatório consolidado em reports/gha/latest_main/ dentro do artefato",
+    "Resumo no GITHUB_STEP_SUMMARY",
+    "Documentação de triagem atualizada antes do merge"
+  ]
+}

--- a/docs/issues/open/issue-132.md
+++ b/docs/issues/open/issue-132.md
@@ -1,0 +1,86 @@
+# Issue #132 — P0: Job noturno para detecção de flaky tests (múltiplas execuções)
+
+- Estado: open
+- Prioridade: P0
+- Labels: enhancement, ci, testing, needs-triage, priority: P0
+- Link: https://github.com/dmirrha/motorsport-calendar/issues/132
+- Criado em: 2025-08-20 08:13 UTC
+
+## Contexto
+A auditoria de testes (`docs/tests/audit/TEST_AUDIT_2025-08-19.md`) recomenda implementar um job agendado para detectar flakiness executando a suíte diversas vezes, consolidando métricas por teste e publicando artefatos para triagem.
+
+## Objetivo
+- Executar a suíte N vezes (5–10) toda madrugada para observar instabilidade.
+- Consolidar resultados por `nodeid` (pytest) com contagens de `passes`, `fails`, `flakes` e taxa de flakiness.
+- Publicar artefatos (logs, JUnit XML, CSV/JSON consolidado) e resumo no job.
+
+## Escopo
+- Novo workflow: `.github/workflows/flaky-nightly.yml`.
+- Gatilhos: `schedule` (cron diário ~03:00 UTC) e `workflow_dispatch` (manual).
+- Execução: 5 a 10 iterações completas da suíte por execução (sem `--maxfail=1` para não interromper métricas). Usar `pytest -q`, `pytest-timeout`, `pytest-randomly`.
+- Saída por iteração:
+  - `junitxml`: `reports/gha/run_${{ github.run_id }}/iter_<N>/junit.xml`
+  - `pytest.log`/stdout: `reports/gha/run_${{ github.run_id }}/iter_<N>/pytest.log`
+- Consolidação:
+  - Agregar JUnit XML em `reports/gha/run_${{ github.run_id }}/summary/`:
+    - `flaky_summary.csv`
+    - `flaky_summary.json`
+    - `summary.md` (resumo humano + top N flaky)
+  - Espelhar para `reports/gha/latest_main/` (somente em execução no `default` branch). Esses arquivos serão publicados como artefatos (não commitados).
+- Publicação:
+  - Upload de artefatos: `name: flaky-nightly-${{ github.run_id }}` com `retention-days: 14`.
+  - `GITHUB_STEP_SUMMARY`: tabela dos testes com maior flakiness.
+
+## Fora de Escopo
+- Alterar a suíte de testes em si.
+- Introduzir commits automáticos no repositório a partir do CI.
+
+## Critérios de Aceite
+- Workflow executa via cron diário (03:00 UTC) e pode ser disparado manualmente.
+- Artefatos contendo resultados por iteração e consolidados disponíveis para download na execução do workflow.
+- Relatório consolidado acessível na pasta `reports/gha/latest_main/` dentro do artefato e resumo publicado no `GITHUB_STEP_SUMMARY`.
+- Documentação atualizada com instruções de triagem (README/overview) antes do merge da PR, seguindo a preferência de deixar S5 por último (hub PR #110).
+
+## Plano de Resolução
+1) Configurar workflow `.github/workflows/flaky-nightly.yml`:
+   - `on: schedule` (cron `0 3 * * *`) e `workflow_dispatch`.
+   - Rodar apenas no `default` branch em `schedule`.
+   - Reutilizar setup do `.github/workflows/tests.yml` (instalação deps, cache pip, etc.).
+2) Executar suíte em loop (ex.: `ITERATIONS=6`):
+   - Para cada iteração: setar `PYTEST_ADDOPTS` com `-q -rA --timeout=60 --durations=25 --junitxml=<path>`.
+   - Opcional: variar `--randomly-seed` por iteração para aumentar cobertura de ordem aleatória.
+   - Salvar logs/saídas por iteração em `reports/gha/run_${{ github.run_id }}/iter_<N>/`.
+3) Consolidação de resultados:
+   - Script Python (embutido no job) para agregar todos os `junit.xml`:
+     - Por `nodeid`: contar `runs`, `passes`, `fails`, `skips` e derivar `flaky = 1 se passes>0 e fails>0`.
+     - Exportar `flaky_summary.csv` e `flaky_summary.json`.
+     - Gerar `summary.md` com top N por flakiness e dicas de triagem.
+4) Publicação:
+   - Copiar `summary/*` também para `reports/gha/latest_main/` quando branch = default.
+   - Upload de artefatos (pasta `reports/gha/`).
+   - Imprimir resumo em `GITHUB_STEP_SUMMARY` (tabela compacta + links de artefatos).
+5) Documentação (no fim):
+   - Atualizar `docs/tests/overview.md` (nova seção Flaky Nightly), `README.md` (referência rápida), `CHANGELOG.md` e `RELEASES.md`.
+   - Manter alinhado ao hub PR #110 e processo SemVer adotado.
+
+## Riscos e Mitigações
+- Tempo de execução elevado: manter `-q`, usar `pytest-timeout`, limitar `ITERATIONS` inicial (ex.: 5-6) e ajustar depois.
+- Intermitência por ambiente de CI: fixar versão de Python/OS igual ao `tests.yml`, cache de deps, seeds variados.
+- Ruído por testes genuinamente quebrados: consolidar por período e observar tendência antes de ações corretivas.
+
+## Tarefas
+- [ ] Criar workflow `.github/workflows/flaky-nightly.yml` com cron e manual.
+- [ ] Loop de iterações, coleta de `junit.xml` e logs.
+- [ ] Consolidação em CSV/JSON e `summary.md`.
+- [ ] Upload de artefatos e `GITHUB_STEP_SUMMARY`.
+- [ ] Atualizar documentação e release notes.
+
+## Referências
+- `.github/workflows/tests.yml`
+- `docs/tests/audit/TEST_AUDIT_2025-08-19.md`
+- `reports/gha/`
+- `requirements-dev.txt` (pytest, pytest-cov, pytest-timeout, pytest-randomly)
+
+---
+
+PEDE CONFIRMAÇÃO: Confirmar este plano para iniciar a implementação do workflow.


### PR DESCRIPTION
CI: adiciona workflow noturno para detecção de flaky tests (agendado + manual)

- Novo workflow: `.github/workflows/flaky-nightly.yml`
- Gatilhos: cron diário 03:00 UTC (`0 3 * * *`) e `workflow_dispatch`
- Execução: padrão 6 iterações (configurável), `pytest -q -rA --timeout=60 --durations=25` com `pytest-randomly` (seed variável)
- Coleta por iteração: `junit.xml`, `pytest.log` em `reports/gha/run_${{ github.run_id }}/iter_<N>/`
- Consolidação: `flaky_summary.csv`, `flaky_summary.json`, `summary.md` em `.../summary/`
- Espelho: `reports/gha/latest_main/` (apenas default branch)
- Artefatos publicados: `reports/gha/` (retenção 14 dias)
- Resumo no `GITHUB_STEP_SUMMARY`

Critérios de aceite atendidos:
- Execução via cron e manual
- Artefatos com resultados consolidados disponíveis para download
- Sumário gerado com top flaky

Documentação (README/docs/tests/overview/CHANGELOG/RELEASES) será atualizada por último antes do merge, alinhado à preferência do hub PR #110.

Closes #132.