### PR TITLE
docs(mutmut): registrar fix para .coverage no baseline (--use-coverage)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,10 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/spec/v2.0.
    - `tests/README.md`: seção de CI atualizada para refletir remoção de `-c /dev/null` e neutralização do gate de cobertura via `--cov-fail-under=0` nos jobs `integration` e `e2e_happy`; adicionada seção prática “Mutation testing (mutmut)” com alvos do Makefile e dicas de uso.
    - `docs/tests/overview.md`: adicionada seção “Mutation testing (mutmut)” com os alvos `make mutmut.run.unit|integration|all`, `mutmut.results`, `mutmut.show` e `mutmut.clean`, além de dicas de paralelismo/ajustes do runner.
    - Makefile: alvos confirmados sem mudanças (`mutmut.run.unit`, `mutmut.run.integration`, `mutmut.run.all`, `mutmut.results`, `mutmut.show`, `mutmut.clean`).
-
+  - Fix — Mutmut Baseline: geração de `.coverage`
+    - Makefile: o alvo `mutmut-baseline` agora executa `coverage run -m pytest -q -o addopts= -p no:cov` antes de invocar `mutmut run --use-coverage`, garantindo a criação do arquivo `.coverage`.
+    - Efeito: elimina o erro `FileNotFoundError: No .coverage file found` observado no workflow e assegura a aplicação correta do `--use-coverage` durante o baseline.
+    - Workflow: `.github/workflows/mutmut-baseline.yml` segue chamando `make mutmut-baseline`; execução permanece informativa (`continue-on-error: true`) enquanto estabilizamos a suíte de mutação.
 - Tests/ICS — Normalização de DESCRIPTION e unfolding de linhas (PR #148)
   - `tests/utils/ical_snapshots.py::normalize_ics_text`:
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -38,6 +38,12 @@ CI — Mutmut Baseline nightly (informativo) e Badge no README (Issue #144)
 - README: adicionado badge "Mutmut Baseline" apontando para o workflow para visibilidade rápida dos resultados.
 - Rastreabilidade: Issue #144.
 
+Fix — Geração de .coverage antes do baseline do Mutmut (Issue #144)
+
+- Makefile: o alvo `mutmut-baseline` passou a executar `coverage run -m pytest -q -o addopts= -p no:cov` antes do `mutmut run --use-coverage`, garantindo a presença do arquivo `.coverage`.
+- Efeito: elimina o erro `FileNotFoundError: No .coverage file found` e assegura que o `--use-coverage` seja aplicado corretamente no baseline.
+- Workflow: `.github/workflows/mutmut-baseline.yml` continua invocando `make mutmut-baseline`; execução permanece informativa enquanto estabilizamos o baseline.
+
 Docs — Limpeza de referências desatualizadas de PR
 
 - Removidas referências de PR obsoletas em `CHANGELOG.md`, `RELEASES.md` e docs de issues para evitar ambiguidade histórica e manter a rastreabilidade coesa. Sem impacto funcional.


### PR DESCRIPTION
Este PR documenta o fix do baseline do Mutmut para geração do arquivo .coverage antes de executar o mutmut com --use-coverage.

Mudanças:
- CHANGELOG.md: seção [Unreleased] — adicionada nota do fix (Makefile gera .coverage antes do baseline; elimina FileNotFoundError no workflow).
- RELEASES.md: seção 'Não Lançado' — adicionada nota do fix e alinhamento com o workflow mutmut-baseline.

Notas:
- O Makefile já contém a correção no alvo 'mutmut-baseline': primeiro roda a suíte com coverage (desabilitando addopts e plugin pytest-cov via -o addopts= e -p no:cov) e só então executa o mutmut com --use-coverage.
- O workflow `.github/workflows/mutmut-baseline.yml` segue invocando `make mutmut-baseline` e permanece informativo (continue-on-error: true) enquanto estabilizamos a suíte de mutação.

Pós-merge:
- Disparar manualmente o workflow "Mutmut Baseline" na main e validar que não há mais o erro: 'No .coverage file found' e que os artefatos são publicados.

Resolves: #144
