### PR TITLE
fix(mutmut): robustez no baseline garantindo .coverage (erase/combine + ls)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,9 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/spec/v2.0.
     - Makefile: o alvo `mutmut-baseline` agora executa `coverage run -m pytest -q -o addopts= -p no:cov` antes de invocar `mutmut run --use-coverage`, garantindo a criação do arquivo `.coverage`.
     - Efeito: elimina o erro `FileNotFoundError: No .coverage file found` observado no workflow e assegura a aplicação correta do `--use-coverage` durante o baseline.
     - Workflow: `.github/workflows/mutmut-baseline.yml` segue chamando `make mutmut-baseline`; execução permanece informativa (`continue-on-error: true`) enquanto estabilizamos a suíte de mutação.
-- Tests/ICS — Normalização de DESCRIPTION e unfolding de linhas (PR #148)
+  - Robustez — Mutmut Baseline: garantir e inspecionar `.coverage`
+    - Makefile: adicionados `coverage erase || true`, `coverage combine || true` e `ls -la .coverage* || true` no alvo `mutmut-baseline` para garantir a presença do arquivo e facilitar depuração em CI.
+ - Tests/ICS — Normalização de DESCRIPTION e unfolding de linhas (PR #148)
   - `tests/utils/ical_snapshots.py::normalize_ics_text`:
 
 ## [0.6.2] - 2025-08-20

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,10 @@ mutmut.run.all:
 
 # Baseline: foca em módulos críticos, executando a suíte completa de testes como runner
 mutmut-baseline:
+ 	coverage erase || true
+ 	coverage run -m pytest -q -o addopts= -p no:cov $(PYTEST_ARGS)
+ 	coverage combine || true
+ 	ls -la .coverage* || true
 	$(MUTMUT) run $(MUTMUT_ARGS) --use-coverage --tests-dir=tests --runner="$(MUTMUT_RUNNER_BASE)" --paths-to-mutate src/event_processor.py
 	$(MUTMUT) run $(MUTMUT_ARGS) --use-coverage --tests-dir=tests --runner="$(MUTMUT_RUNNER_BASE)" --paths-to-mutate src/ical_generator.py
 	$(MUTMUT) run $(MUTMUT_ARGS) --use-coverage --tests-dir=tests --runner="$(MUTMUT_RUNNER_BASE)" --paths-to-mutate sources/base_source.py

--- a/Makefile
+++ b/Makefile
@@ -76,10 +76,10 @@ mutmut.run.all:
 
 # Baseline: foca em módulos críticos, executando a suíte completa de testes como runner
 mutmut-baseline:
- 	coverage erase || true
- 	coverage run -m pytest -q -o addopts= -p no:cov $(PYTEST_ARGS)
- 	coverage combine || true
- 	ls -la .coverage* || true
+	coverage erase || true
+	coverage run -m pytest -q -o addopts= -p no:cov $(PYTEST_ARGS)
+	coverage combine || true
+	ls -la .coverage* || true
 	$(MUTMUT) run $(MUTMUT_ARGS) --use-coverage --tests-dir=tests --runner="$(MUTMUT_RUNNER_BASE)" --paths-to-mutate src/event_processor.py
 	$(MUTMUT) run $(MUTMUT_ARGS) --use-coverage --tests-dir=tests --runner="$(MUTMUT_RUNNER_BASE)" --paths-to-mutate src/ical_generator.py
 	$(MUTMUT) run $(MUTMUT_ARGS) --use-coverage --tests-dir=tests --runner="$(MUTMUT_RUNNER_BASE)" --paths-to-mutate sources/base_source.py

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -44,6 +44,10 @@ Fix — Geração de .coverage antes do baseline do Mutmut (Issue #144)
 - Efeito: elimina o erro `FileNotFoundError: No .coverage file found` e assegura que o `--use-coverage` seja aplicado corretamente no baseline.
 - Workflow: `.github/workflows/mutmut-baseline.yml` continua invocando `make mutmut-baseline`; execução permanece informativa enquanto estabilizamos o baseline.
 
+ Robustez — Baseline do Mutmut: garantir e inspecionar `.coverage`
+
+- Makefile: adicionados `coverage erase || true`, `coverage combine || true` e `ls -la .coverage* || true` ao alvo `mutmut-baseline` para garantir a existência do arquivo `.coverage` e facilitar depuração no CI.
+
 Docs — Limpeza de referências desatualizadas de PR
 
 - Removidas referências de PR obsoletas em `CHANGELOG.md`, `RELEASES.md` e docs de issues para evitar ambiguidade histórica e manter a rastreabilidade coesa. Sem impacto funcional.


### PR DESCRIPTION
Melhora o alvo 'mutmut-baseline' no Makefile para garantir criação e visibilidade do arquivo .coverage antes de executar o mutmut com --use-coverage.\n\nMudanças:\n- Makefile: adicionados 'coverage erase || true', 'coverage run -m pytest -q -o addopts= -p no:cov', 'coverage combine || true' e 'ls -la .coverage* || true'.\n- CHANGELOG.md e RELEASES.md: notas de robustez adicionadas em [Unreleased]/Não Lançado.\n\nValidação proposta (pré-merge):\n- Rodar o workflow "Mutmut Baseline" apontando para esta branch e verificar no log a listagem '.coverage*' e ausência do erro 'No .coverage file found'.