### PR TITLE
CI: Mutmut Baseline bloqueante (remove continue-on-error); bump 0.6.3

### DIFF
--- a/.github/workflows/mutmut-baseline.yml
+++ b/.github/workflows/mutmut-baseline.yml
@@ -49,7 +49,6 @@ jobs:
           echo "pytest: $(pytest --version)"
 
       - name: Run mutmut baseline (serial)
-        continue-on-error: true
         env:
           TZ: America/Sao_Paulo
         run: |

--- a/.github/workflows/mutmut-baseline.yml
+++ b/.github/workflows/mutmut-baseline.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   baseline:
-    name: Run mutmut baseline (informativo)
+    name: Run mutmut baseline
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ coverage.xml
 coverage_*.xml
 *.cover
 .hypothesis/
+.mutmut-cache/
 pytest.log
 report.html
 junit.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/spec/v2.0.
   - Fix — Mutmut Baseline: geração de `.coverage`
     - Makefile: o alvo `mutmut-baseline` agora executa `coverage run -m pytest -q -o addopts= -p no:cov` antes de invocar `mutmut run --use-coverage`, garantindo a criação do arquivo `.coverage`.
     - Efeito: elimina o erro `FileNotFoundError: No .coverage file found` observado no workflow e assegura a aplicação correta do `--use-coverage` durante o baseline.
-    - Workflow: `.github/workflows/mutmut-baseline.yml` segue chamando `make mutmut-baseline`; execução permanece informativa (`continue-on-error: true`) enquanto estabilizamos a suíte de mutação.
+    - Workflow: `.github/workflows/mutmut-baseline.yml` segue chamando `make mutmut-baseline`; execução agora é bloqueante (removido `continue-on-error: true`) após estabilização do baseline.
   - Robustez — Mutmut Baseline: garantir e inspecionar `.coverage`
     - Makefile: adicionados `coverage erase || true`, `coverage combine || true` e `ls -la .coverage* || true` no alvo `mutmut-baseline` para garantir a presença do arquivo e facilitar depuração em CI.
  - Tests/ICS — Normalização de DESCRIPTION e unfolding de linhas (PR #148)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -33,7 +33,7 @@ CI — Mutmut Baseline nightly (informativo) e Badge no README (Issue #144)
 - Workflow adicionado: `.github/workflows/mutmut-baseline.yml` (nome: "Mutmut Baseline").
   - Agenda: diariamente às 04:00 UTC (`schedule`) e disparo manual (`workflow_dispatch`).
   - Execução: `make mutmut-baseline` em modo serial (sem xdist) para compatibilidade com `--use-coverage` do Mutmut; coleta `mutmut results` e publica no Job Summary; artefatos enviados (`mutmut_results.txt`, `.mutmut-cache/`).
-  - Passo temporariamente não-bloqueante (`continue-on-error: true`) enquanto a suíte de mutação é estabilizada.
+  - Passo agora bloqueante (removido `continue-on-error: true`) após estabilização do baseline de mutação.
   - Permissões mínimas; informativo (não gateia PRs).
 - README: adicionado badge "Mutmut Baseline" apontando para o workflow para visibilidade rápida dos resultados.
 - Rastreabilidade: Issue #144.
@@ -42,7 +42,7 @@ Fix — Geração de .coverage antes do baseline do Mutmut (Issue #144)
 
 - Makefile: o alvo `mutmut-baseline` passou a executar `coverage run -m pytest -q -o addopts= -p no:cov` antes do `mutmut run --use-coverage`, garantindo a presença do arquivo `.coverage`.
 - Efeito: elimina o erro `FileNotFoundError: No .coverage file found` e assegura que o `--use-coverage` seja aplicado corretamente no baseline.
-- Workflow: `.github/workflows/mutmut-baseline.yml` continua invocando `make mutmut-baseline`; execução permanece informativa enquanto estabilizamos o baseline.
+- Workflow: `.github/workflows/mutmut-baseline.yml` continua invocando `make mutmut-baseline`; execução agora é bloqueante (sem `continue-on-error`).
 
  Robustez — Baseline do Mutmut: garantir e inspecionar `.coverage`
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import importlib
 from typing import Any
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"
 __author__ = "Daniel Mirrha"
 __email__ = "dmirrha@gmail.com"
 


### PR DESCRIPTION
CI: tornar Mutmut Baseline bloqueante.

- Remove continue-on-error no passo "Run mutmut baseline (serial)".
- Atualiza CHANGELOG.md e RELEASES.md.
- Bump versão 0.6.3 em src/__init__.py.

Validação: workflow Mutmut Baseline será disparado via workflow_dispatch nesta branch.

Closes #144.